### PR TITLE
feat: support markdown frontmatter and HTML export in geo-optimize

### DIFF
--- a/.claude/agents/geo-analyzer.md
+++ b/.claude/agents/geo-analyzer.md
@@ -22,7 +22,7 @@ For URLs, extract:
 - Existing schema markup
 - Key phrases and topics
 
-For files, read and parse the content directly.
+For files, read and parse the content directly. If the file contains frontmatter (YAML/TOML headers), ignore the frontmatter block when analyzing and scoring the body content.
 
 ### 2. GEO Signal Detection
 Score each of the 10 GEO features (0-10):

--- a/.claude/agents/geo-rewriter.md
+++ b/.claude/agents/geo-rewriter.md
@@ -28,7 +28,7 @@ Transform content to rank higher in AI-powered search engines while preserving b
 - All factual claims (verify or flag if uncertain)
 - Core messaging and value proposition
 - Existing keywords and SEO elements
-- Existing markdown frontmatter (YAML/TOML headers); do not modify, strip, or rewrite them.
+- Existing markdown frontmatter (YAML/TOML headers); do not modify, strip, or rewrite them. (In the standard pipeline, frontmatter is extracted before content reaches this agent, but preserve it if encountered.)
 
 ### Must Avoid
 - Fabricating statistics or testimonials

--- a/.claude/agents/geo-rewriter.md
+++ b/.claude/agents/geo-rewriter.md
@@ -28,6 +28,7 @@ Transform content to rank higher in AI-powered search engines while preserving b
 - All factual claims (verify or flag if uncertain)
 - Core messaging and value proposition
 - Existing keywords and SEO elements
+- Existing markdown frontmatter (YAML/TOML headers); do not modify, strip, or rewrite them.
 
 ### Must Avoid
 - Fabricating statistics or testimonials

--- a/.claude/commands/geo-audit.md
+++ b/.claude/commands/geo-audit.md
@@ -14,7 +14,7 @@ Analysis-only mode. Scores content and identifies gaps without rewriting.
 ## Workflow
 
 0. **Validate MCPs** - Run `validation-doctor`; if missing, provide setup snippets
-1. **Extract** - Get content from URL or file (source of truth)
+1. **Extract** - Get content from URL or file (source of truth). If the target is a local file with frontmatter (YAML/TOML), ignore the frontmatter block when analyzing and scoring.
 2. **Score** - Rate against 10 GEO criteria based on analyzer output
 3. **Rank** - Estimate AI-engine position based on analyzer output (Brave if available)
 4. **Report** - Output findings and recommendations

--- a/.claude/commands/geo-optimize.md
+++ b/.claude/commands/geo-optimize.md
@@ -5,6 +5,9 @@ arguments:
   - name: file
     description: Path to content file to optimize
     required: true
+  - name: format
+    description: Output format (markdown or html, default is markdown)
+    required: false
 ---
 
 # /geo:optimize Command
@@ -14,14 +17,17 @@ Quick optimization of local content files.
 ## Workflow
 
 0. **Validate MCPs** - Run `validation-doctor`; if missing, provide setup snippets
-1. **Analyze** - Read and score file content (source of truth)
-2. **Rewrite** - Apply GEO optimization based on analyzer output
-3. **Schema** - Generate appropriate markup based on analyzer output
-4. **Save** - Output optimized version
+1. **Frontmatter Extraction** - If the input file contains frontmatter (YAML block between `---` or TOML block between `+++`), extract and preserve this block completely. Do not pass the frontmatter to the analyzer or rewriter agents. Only pass the content body.
+2. **Analyze** - Read and score the content body (source of truth)
+3. **Rewrite** - Apply GEO optimization to the content body based on analyzer output
+4. **Schema** - Generate appropriate markup based on analyzer output
+5. **Reassemble & Export** - Output the optimized version to the `geo-output/optimized/` directory:
+   - **markdown**: Reassemble the file by prepending the original, unmodified frontmatter to the optimized content body. Save as `[name].md`.
+   - **html**: Convert the optimized content body to HTML (preserving all headers, tables, lists, and formatting). Insert the original frontmatter properties into appropriate HTML metadata tags (`<meta>` or structured header) inside a clean, modern HTML document template. Save as `[name].html`.
 
 ## Output
 
-- Optimized content with before/after comparison
+- Optimized content (with frontmatter preserved or converted to HTML metadata)
 - Schema markup if applicable
 - Change summary with impact estimates
 
@@ -29,5 +35,6 @@ Quick optimization of local content files.
 
 ```
 /geo:optimize ./content/homepage.md
-/geo:optimize ./blog/new-post.md
+/geo:optimize ./content/homepage.md --format html
+/geo:optimize ./blog/new-post.md --format markdown
 ```

--- a/.claude/commands/geo-optimize.md
+++ b/.claude/commands/geo-optimize.md
@@ -35,6 +35,6 @@ Quick optimization of local content files.
 
 ```
 /geo:optimize ./content/homepage.md
-/geo:optimize ./content/homepage.md --format html
-/geo:optimize ./blog/new-post.md --format markdown
+/geo:optimize ./content/homepage.md html
+/geo:optimize ./blog/new-post.md markdown
 ```

--- a/.claude/commands/geo.md
+++ b/.claude/commands/geo.md
@@ -14,7 +14,7 @@ Execute full GEO optimization pipeline.
 ## Workflow
 
 0. **Validate MCPs** - Run `validation-doctor`; if missing, provide setup snippets
-1. **Frontmatter Detection** - If the target is a local file containing frontmatter (YAML/TOML blocks), extract and preserve it completely unchanged. Only pass the remaining body content to the analyzer and rewriter.
+1. **Frontmatter Extraction** - If the target is a local file containing frontmatter (YAML/TOML blocks), extract and preserve it completely unchanged. Only pass the remaining body content to the analyzer and rewriter.
 2. **Analyze** - Extract and score current content body (source of truth)
 3. **Rank** - Simulate baseline AI-engine ranking based on analyzer output
 4. **Rewrite** - Optimize content using analyzer findings. If the target was a local file with frontmatter, prepend the original unmodified frontmatter block to the optimized content body when saving.
@@ -26,22 +26,25 @@ Execute full GEO optimization pipeline.
 ```
 Analyzing: $ARGUMENTS.target
 
-Step 0/6: MCP Validation
+Step 0/7: MCP Validation
 → Running validation-doctor...
 
-Step 1/6: Content Analysis
+Step 1/7: Frontmatter Extraction
+→ Extracting and preserving frontmatter if present...
+
+Step 2/7: Content Analysis
 → Delegating to geo-analyzer...
 
-Step 2/6: Ranking Simulation  
+Step 3/7: Ranking Simulation
 → Delegating to geo-ranker...
 
-Step 3/6: Content Optimization
+Step 4/7: Content Optimization
 → Delegating to geo-rewriter...
 
-Step 4/6: Schema Generation
+Step 5/7: Schema Generation
 → Delegating to geo-indexer...
 
-Step 5/6: Report Compilation
+Step 6/7: Report Compilation
 → Generating final report...
 ```
 
@@ -50,7 +53,7 @@ Step 5/6: Report Compilation
 Save results to `geo-output/` folder:
 - `report.md` - Executive summary with scores
 - `analysis.json` - Raw analysis data
-- `optimized/[name].md` - Rewritten content
+- `optimized/[name].[ext]` - Rewritten content (`.md` or `.html` depending on format)
 - `schema/[name].json` - JSON-LD markup
 - `checklist.md` - Implementation steps
 

--- a/.claude/commands/geo.md
+++ b/.claude/commands/geo.md
@@ -14,11 +14,12 @@ Execute full GEO optimization pipeline.
 ## Workflow
 
 0. **Validate MCPs** - Run `validation-doctor`; if missing, provide setup snippets
-1. **Analyze** - Extract and score current content (source of truth)
-2. **Rank** - Simulate baseline AI-engine ranking based on analyzer output
-3. **Rewrite** - Optimize content using analyzer findings
-4. **Index** - Generate schema markup using analyzer findings
-5. **Report** - Compile results using analyzer output + validation status
+1. **Frontmatter Detection** - If the target is a local file containing frontmatter (YAML/TOML blocks), extract and preserve it completely unchanged. Only pass the remaining body content to the analyzer and rewriter.
+2. **Analyze** - Extract and score current content body (source of truth)
+3. **Rank** - Simulate baseline AI-engine ranking based on analyzer output
+4. **Rewrite** - Optimize content using analyzer findings. If the target was a local file with frontmatter, prepend the original unmodified frontmatter block to the optimized content body when saving.
+5. **Index** - Generate schema markup using analyzer findings
+6. **Report** - Compile results using analyzer output + validation status
 
 ## Execution
 


### PR DESCRIPTION
This PR resolves issues #2 and #4. It adds frontmatter preservation to the local file optimization pipeline (ignoring YAML/TOML blocks during analysis/rewriting and reassembling them when saving), and adds the --format argument to export the optimized content to HTML.