### PR TITLE
feat(geo-indexer): add Organization schema template

### DIFF
--- a/.claude/agents/geo-indexer.md
+++ b/.claude/agents/geo-indexer.md
@@ -154,8 +154,8 @@ Select appropriate schema type based on content:
   "url": "",
   "logo": "",
   "sameAs": [
-    "https://www.linkedin.com/company/",
-    "https://twitter.com/"
+    "",
+    ""
   ],
   "address": {
     "@type": "PostalAddress",
@@ -168,7 +168,8 @@ Select appropriate schema type based on content:
   "contactPoint": {
     "@type": "ContactPoint",
     "contactType": "customer service",
-    "email": ""
+    "email": "",
+    "telephone": ""
   }
 }
 ```

--- a/.claude/agents/geo-indexer.md
+++ b/.claude/agents/geo-indexer.md
@@ -144,6 +144,35 @@ Select appropriate schema type based on content:
 }
 ```
 
+### Organization / Company
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "",
+  "description": "",
+  "url": "",
+  "logo": "",
+  "sameAs": [
+    "https://www.linkedin.com/company/",
+    "https://twitter.com/"
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "",
+    "addressLocality": "",
+    "addressRegion": "",
+    "postalCode": "",
+    "addressCountry": ""
+  },
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "customer service",
+    "email": ""
+  }
+}
+```
+
 ## Rules
 - Always output valid JSON-LD
 - Include implementation instructions


### PR DESCRIPTION
## Problem

The geo-indexer agent mentions Organization schema in the Asset Types table (line 27) but has no dedicated template for it. Users generating schema markup for company/about pages have no copy-paste ready reference.

## Fix

Added an **Organization / Company** schema template following the same format as existing templates (SaaS Product, B2B Service, B2C Product). Includes:

- Core fields: name, description, url, logo
- Social links via sameAs (LinkedIn, Twitter)
- Full PostalAddress with locality details
- ContactPoint for customer service

## Test Plan

- [x] Template follows the same JSON-LD format as existing templates
- [x] All fields use schema.org types (Organization, PostalAddress, ContactPoint)
- [x] Matches the fields listed in the issue: name, description, url, logo, sameAs, address

Closes #1