### PR TITLE
v2.0: Runtime adapter layer + standalone `egeo` CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,19 @@ jobs:
             --dataset eval/datasets/geo_smoke.jsonl \
             --limit 5 \
             --verbose
+
+      # 6. Smoke test the standalone `egeo` runtime CLI (MOCK client, offline)
+      - name: Smoke test egeo CLI (MOCK client)
+        env:
+          GEO_EVAL_MOCK: "1"
+        run: |
+          # List runtime adapters (python/cli + claude-code descriptor)
+          python -m egeo runtimes
+          # evaluate must reuse geo_eval.py and produce identical results
+          python -m egeo evaluate \
+            --dataset eval/datasets/geo_smoke.jsonl \
+            --limit 3
+          # Full optimize pipeline -> writes report + optimized content + schema
+          python -m egeo optimize examples/sample-input.md --out-dir /tmp/egeo-smoke
+          # The emitted JSON-LD must validate with the same checker used above
+          python scripts/validate_jsonld.py /tmp/egeo-smoke/schema/*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v2.0.0)"
+        required: true
+
+permissions:
+  contents: write   # required to create a GitHub Release
+
+jobs:
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for changelog diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract notes from CHANGELOG.md
+        id: notes
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          VERSION="${TAG#v}"
+          # Pull the section for this version out of CHANGELOG.md (Keep a Changelog format)
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+            /^## \[/ {flag=0}
+            flag {print}
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "No CHANGELOG section for $VERSION; using auto-generated notes." > release_notes.md
+          fi
+
+      - name: Create / update release
+        env:
+          GH_TOKEN: ${{ github.token }}   # GitHub-injected, NOT a PAT
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release_notes.md \
+            --verify-tag \
+            --latest \
+          || gh release edit "$TAG" --notes-file release_notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,11 @@
 
 # Non-destructive optimize output (generated candidate prompt)
 /prompts/*.candidate.txt
+
+# Python / packaging artifacts (egeo CLI)
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.eggs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to E-GEO are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Runtime-agnostic execution: a standalone `egeo` CLI and a pluggable runtime
+adapter layer, so the same GEO engine runs outside Claude Code without
+duplicating any optimization logic.
+
+### Added
+
+- **Runtime adapter layer** (`egeo/runtimes.py`): a `RuntimeAdapter` interface
+  with a `python` (aliases `cli`, `local`) in-process adapter and a
+  `claude-code` (alias `claude`) host-executed descriptor, plus a small registry
+  (`get_runtime`, `list_runtimes`, `runtime_status`). New `egeo runtimes`
+  command prints live adapter status.
+- **Standalone `egeo` CLI** (`egeo/cli.py`, `python -m egeo`) exposing:
+  - `optimize <file>` — full pipeline (analyze → rank → rewrite → schema) that
+    writes `report.md`, `optimized/*.md`, `schema/*.json`, and `analysis.json`.
+  - `evaluate` — the evaluation harness, delegating to `geo_eval.py` with
+    byte-identical output.
+  - `optimize-prompts` — meta-optimizes the rewriter prompt (non-destructive by
+    default, mirroring `geo_eval.py optimize`).
+  - `runtimes` — list available runtime adapters.
+- **Agent wrappers** (`egeo/agents.py`) and **pipeline** (`egeo/pipeline.py`)
+  that reuse `geo_eval.py` (`_rank_candidates`, `_rewrite_description`) and
+  `llm_client.py` — **no duplicated optimization logic**. The whole CLI honors
+  `GEO_EVAL_MOCK=1` for deterministic, offline runs (no API key).
+- **Packaging** (`pyproject.toml`): installs the `egeo` package alongside the
+  existing `geo_eval`/`llm_client` modules and registers the `egeo` console
+  script (`pip install -e .`).
+- **Release automation** (`.github/workflows/release.yml`): on `v*` tags (or
+  manual `workflow_dispatch`), extracts the matching `CHANGELOG.md` section and
+  publishes a GitHub Release via `gh`, using the GitHub-injected token (no PAT).
+- **OpenSpec change** `add-runtime-adapters` with proposal, tasks, design, and a
+  new `runtime-adapters` capability spec.
+
+### Changed
+
+- **CI** (`.github/workflows/ci.yml`): added a CLI smoke test that runs
+  `egeo runtimes`, `egeo evaluate`, and a full `egeo optimize` under
+  `GEO_EVAL_MOCK=1`, then validates the emitted JSON-LD. Existing quality gates
+  are unchanged.
+- **README.md**: new "Standalone CLI (`egeo`)" and "Supported Runtimes" sections
+  documenting installation, commands, offline mode, and the runtime matrix.
+
 ## [1.1.0] - 2026-06-29
 
 Quality hardening and a transparent, reproducible evaluation harness.
@@ -49,4 +92,5 @@ Quality hardening and a transparent, reproducible evaluation harness.
 - Evaluation metrics are an **LLM-ranker proxy**, not a measurement of real
   AI-search engine rankings. See `docs/evaluation.md`.
 
+[Unreleased]: https://github.com/mverab/eGEOagents/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/mverab/eGEOagents/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -208,6 +208,72 @@ pull request. Reported metrics: `avg_rank_improvement`, `win_rate`, and
 
 ---
 
+## 🖥️ Standalone CLI (`egeo`)
+
+Beyond Claude Code, E-GEO ships a **runtime-agnostic command line** so the same
+GEO engine runs anywhere Python runs — local shells, notebooks, Docker, or CI.
+The CLI is a thin wrapper around the **exact same** `geo_eval.py` and
+`llm_client.py` modules used by the Claude Code agents, so there is **no
+duplicated optimization logic** — both runtimes share one source of truth.
+
+### Install
+
+```bash
+# From the repo root — installs the `egeo` console script + deps
+pip install -e .
+
+# ...or run without installing (deps: pip install pyyaml jsonschema)
+python -m egeo --help
+```
+
+### Commands
+
+| Command | What it does |
+|---------|--------------|
+| `egeo optimize <file>` | **Full pipeline** — analyze → rank → rewrite → schema, writes `report.md`, `optimized/*.md`, `schema/*.json`, `analysis.json` |
+| `egeo evaluate` | Run the evaluation harness (reuses `geo_eval.py`, identical metrics) |
+| `egeo optimize-prompts` | Meta-optimize the rewriter prompt (non-destructive by default) |
+| `egeo runtimes` | List available runtime adapters and their status |
+
+```bash
+# Optimize a local content file (output dir defaults to ./geo-output)
+egeo optimize examples/sample-input.md --out-dir ./geo-output
+
+# Score prompt quality on a dataset
+egeo evaluate --dataset eval/datasets/geo_smoke.jsonl --limit 5
+
+# Inspect the runtime adapters
+egeo runtimes
+```
+
+### Offline / deterministic mode
+
+Every command honors `GEO_EVAL_MOCK=1`, which swaps in a deterministic mock LLM
+client — **no API key required**. This is exactly how the CLI is exercised in
+[CI](.github/workflows/ci.yml):
+
+```bash
+GEO_EVAL_MOCK=1 egeo optimize examples/sample-input.md --out-dir /tmp/egeo
+GEO_EVAL_MOCK=1 egeo evaluate --dataset eval/datasets/geo_smoke.jsonl --limit 3
+```
+
+### Supported Runtimes
+
+E-GEO exposes a small **runtime adapter** layer so the same agents (Analyzer,
+Ranker, Rewriter, Indexer) can be driven by different execution hosts:
+
+| Runtime | Aliases | Mode | Status | Description |
+|---------|---------|------|:------:|-------------|
+| **`python`** | `cli`, `local` | in-process | ✅ Available | Pure-Python runtime behind the `egeo` CLI. Runs the full pipeline in-process and honors `GEO_EVAL_MOCK` for offline, deterministic runs. |
+| **`claude-code`** | `claude` | host-executed | ✅ Available | Executes the `.claude/` agents through Claude Code `/geo` slash commands on the host. Auto-detected when a `.claude/` directory is present. |
+
+> Run `egeo runtimes` to print the live status of each adapter in your
+> environment. Additional hosts (Cursor, Codex, Windsurf, …) can be added by
+> implementing the `RuntimeAdapter` interface in
+> [`egeo/runtimes.py`](egeo/runtimes.py).
+
+---
+
 ## 🆚 E-GEO vs Alternatives
 
 | Feature | E-GEO | Traditional SEO | Manual GEO |

--- a/egeo/__init__.py
+++ b/egeo/__init__.py
@@ -1,0 +1,35 @@
+"""E-GEO runtime adapter layer and standalone ``egeo`` CLI.
+
+This package decouples the four GEO agents (Analyzer, Ranker, Rewriter, Indexer)
+from any single host runtime. The agent *contract* is defined once in
+:mod:`egeo.agents`; concrete runtimes plug in implementations via
+:mod:`egeo.runtimes`. The :mod:`egeo.cli` module exposes a runtime-agnostic
+``egeo`` command (``optimize``, ``evaluate``, ``optimize-prompts``, ``runtimes``).
+
+The Ranker and Rewriter agents intentionally *reuse* the existing
+``geo_eval``/``llm_client`` modules at the repository root rather than
+duplicating their logic. To make those root-level modules importable regardless
+of the current working directory (e.g. ``python -m egeo`` from any folder), this
+module bootstraps the repository root onto ``sys.path``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+__version__ = "2.0.0"
+
+# Repository root = parent of this package directory. Adding it to sys.path lets
+# ``import geo_eval`` / ``import llm_client`` succeed even when the CLI is run
+# from outside the repo root or installed in editable mode.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def repo_root() -> Path:
+    """Return the repository root that ships ``geo_eval``/``prompts``/``geo-output``."""
+    return _REPO_ROOT
+
+
+__all__ = ["__version__", "repo_root"]

--- a/egeo/__main__.py
+++ b/egeo/__main__.py
@@ -1,0 +1,7 @@
+"""Enable ``python -m egeo`` to invoke the CLI."""
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/egeo/agents.py
+++ b/egeo/agents.py
@@ -1,0 +1,322 @@
+"""Runtime-agnostic abstractions for the four GEO agents.
+
+The four agents mirror the Claude Code definitions in ``.claude/agents/`` but are
+expressed here as plain Python objects so *any* runtime can construct and run
+them:
+
+- :class:`Analyzer`  — deterministic, offline GEO-signal scorer (no LLM).
+- :class:`Ranker`    — thin wrapper over ``geo_eval._rank_candidates``.
+- :class:`Rewriter`  — thin wrapper over ``geo_eval._rewrite_description``.
+- :class:`Indexer`   — deterministic JSON-LD template filler (no LLM).
+
+The Ranker and Rewriter deliberately delegate to ``geo_eval`` so there is a
+single source of truth for ranking/rewriting logic and prompts. Analyzer and
+Indexer are deterministic and offline, so the full pipeline runs without an API
+key (and therefore under ``GEO_EVAL_MOCK=1`` in CI).
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+# Reuse the harness rather than re-implementing it. The package __init__ has
+# already placed the repo root on sys.path so these imports resolve.
+import geo_eval
+from geo_eval import Candidate
+
+__all__ = [
+    "GEO_FEATURES",
+    "AnalysisResult",
+    "RankResult",
+    "RewriteResult",
+    "SchemaResult",
+    "Analyzer",
+    "Ranker",
+    "Rewriter",
+    "Indexer",
+]
+
+# The 10 universal GEO features (see openspec/project.md and AGENTS.md).
+GEO_FEATURES: List[str] = [
+    "ranking_emphasis",
+    "user_intent",
+    "competitive_diff",
+    "social_proof",
+    "narrative",
+    "authority",
+    "usps",
+    "urgency",
+    "scannable",
+    "factual",
+]
+
+# Human-readable remediation copy used when a feature scores low.
+_RECOMMENDATIONS: Dict[str, str] = {
+    "ranking_emphasis": "Frame the content as a top/leading choice (e.g. 'best for ...').",
+    "user_intent": "Open by directly answering the user's likely question or use case.",
+    "competitive_diff": "Call out concrete advantages over typical alternatives (no competitor names needed).",
+    "social_proof": "Add trust signals: customer counts, ratings, or testimonials (never fabricated).",
+    "narrative": "Tighten the flow into a persuasive, benefit-led story.",
+    "authority": "Add expert, confident phrasing and verifiable credentials or specifics.",
+    "usps": "Make the unique selling points explicit and scannable as bullets.",
+    "urgency": "Add a genuine urgency or scarcity signal where appropriate.",
+    "scannable": "Add headings, bullet lists, and short paragraphs for easy parsing.",
+    "factual": "Keep concrete, verifiable facts (numbers, units) and avoid vague hype.",
+}
+
+
+@dataclass
+class AnalysisResult:
+    """Output of :class:`Analyzer` — GEO-signal scores and gap analysis."""
+
+    title: str
+    content_length: int
+    scores: Dict[str, int]
+    total_score: int
+    gaps: List[Dict[str, str]] = field(default_factory=list)
+    strengths: List[str] = field(default_factory=list)
+    priority_actions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "title": self.title,
+            "content_length": self.content_length,
+            "scores": self.scores,
+            "total_score": self.total_score,
+            "gaps": self.gaps,
+            "strengths": self.strengths,
+            "priority_actions": self.priority_actions,
+        }
+
+
+@dataclass
+class RankResult:
+    """Output of :class:`Ranker` — an ordering of candidate ids."""
+
+    query: str
+    ordered_ids: List[str]
+
+    def position_of(self, candidate_id: str) -> int:
+        """1-based position of ``candidate_id`` in the ordering."""
+        return self.ordered_ids.index(candidate_id) + 1
+
+
+@dataclass
+class RewriteResult:
+    """Output of :class:`Rewriter` — the optimized description."""
+
+    title: str
+    original_description: str
+    rewritten_description: str
+
+
+@dataclass
+class SchemaResult:
+    """Output of :class:`Indexer` — a JSON-LD document."""
+
+    schema_type: str
+    json_ld: Dict[str, Any]
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.json_ld, indent=indent, ensure_ascii=False)
+
+
+# --------------------------------------------------------------------------- #
+# Analyzer (deterministic, offline)
+# --------------------------------------------------------------------------- #
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Remove a leading YAML/TOML frontmatter block if present."""
+    m = re.match(r"^---\s*\n.*?\n---\s*(?:\n|$)", text, re.DOTALL)
+    if m:
+        return text[m.end():]
+    m = re.match(r"^\+\+\+\s*\n.*?\n\+\+\+\s*(?:\n|$)", text, re.DOTALL)
+    if m:
+        return text[m.end():]
+    return text
+
+
+def _clamp(value: int, low: int = 0, high: int = 10) -> int:
+    return max(low, min(high, value))
+
+
+class Analyzer:
+    """Score content against the 10 GEO features with a transparent heuristic.
+
+    This is an *offline proxy* for the Claude ``geo-analyzer`` agent: it never
+    calls an LLM, so it is deterministic and runs with no API key. It looks for
+    the same signals the analyzer prompt describes (superlatives, intent, social
+    proof, structure, etc.).
+    """
+
+    _RANKING_WORDS = ("best", "top", "#1", "number one", "leading", "premier", "ultimate", "trusted", "award")
+    _INTENT_WORDS = ("best for", "ideal for", "designed for", "perfect for", "how to", "what is", "use case", "for businesses", "for teams")
+    _DIFF_WORDS = ("unlike", "compared to", "vs ", "versus", "alternative", "unique", "differentiat", "better than", "outperform")
+    _PROOF_WORDS = ("customer", "users", "rated", "rating", "review", "testimonial", "trusted by", "case study", "%", "stars")
+    _AUTHORITY_WORDS = ("expert", "certified", "proven", "industry", "research", "years", "award-winning", "official", "data shows")
+    _URGENCY_WORDS = ("now", "today", "limited", "offer", "hurry", "deadline", "while supplies", "act fast", "don't miss", "ends ")
+    _NARRATIVE_WORDS = ("because", "so that", "imagine", "whether", "that's why", "which means", "helps you", "you can")
+
+    def analyze(self, content: str, *, title: Optional[str] = None) -> AnalysisResult:
+        body = _strip_frontmatter(content)
+        lower = body.lower()
+        lines = [ln for ln in body.splitlines()]
+        non_empty = [ln for ln in lines if ln.strip()]
+        words = re.findall(r"[A-Za-z0-9#%']+", lower)
+        word_count = len(words)
+
+        if not title:
+            heading = next((ln for ln in lines if ln.strip().startswith("#")), "")
+            title = heading.lstrip("#").strip() or (non_empty[0].strip() if non_empty else "Untitled")
+
+        def keyword_score(keywords: Sequence[str], cap: int = 3) -> int:
+            hits = sum(lower.count(k) for k in keywords)
+            return _clamp(min(hits, cap) * (10 // cap) + (2 if hits else 0))
+
+        bullets = sum(1 for ln in lines if ln.strip().startswith(("-", "*", "•")) or re.match(r"^\s*\d+\.", ln))
+        headings = sum(1 for ln in lines if ln.strip().startswith("#"))
+        numbers = len(re.findall(r"\b\d[\d,\.]*\b", body))
+
+        scores: Dict[str, int] = {
+            "ranking_emphasis": keyword_score(self._RANKING_WORDS),
+            "user_intent": keyword_score(self._INTENT_WORDS),
+            "competitive_diff": keyword_score(self._DIFF_WORDS),
+            "social_proof": _clamp(keyword_score(self._PROOF_WORDS) + (2 if numbers >= 2 else 0)),
+            "narrative": _clamp(keyword_score(self._NARRATIVE_WORDS) + (2 if word_count > 80 else 0)),
+            "authority": keyword_score(self._AUTHORITY_WORDS),
+            "usps": _clamp((6 if bullets >= 3 else bullets * 2) + (2 if "feature" in lower or "benefit" in lower else 0)),
+            "urgency": keyword_score(self._URGENCY_WORDS),
+            "scannable": _clamp((4 if headings >= 1 else 0) + (4 if bullets >= 2 else bullets * 2) + (2 if len(non_empty) >= 4 else 0)),
+            "factual": _clamp(3 + min(numbers, 5) + (2 if numbers >= 3 else 0)),
+        }
+
+        total = sum(scores.values())
+        gaps = [
+            {
+                "feature": feat,
+                "current": f"Low signal (score {scores[feat]}/10)",
+                "recommendation": _RECOMMENDATIONS[feat],
+            }
+            for feat in GEO_FEATURES
+            if scores[feat] < 5
+        ]
+        strengths = [feat for feat in GEO_FEATURES if scores[feat] >= 7]
+        priority = sorted(GEO_FEATURES, key=lambda f: scores[f])[:3]
+        priority_actions = [_RECOMMENDATIONS[f] for f in priority]
+
+        return AnalysisResult(
+            title=title,
+            content_length=len(body),
+            scores=scores,
+            total_score=total,
+            gaps=gaps,
+            strengths=strengths,
+            priority_actions=priority_actions,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Ranker / Rewriter (reuse geo_eval; the only LLM-backed agents)
+# --------------------------------------------------------------------------- #
+
+
+class Ranker:
+    """Simulate AI-engine ranking by delegating to ``geo_eval._rank_candidates``."""
+
+    def __init__(self, *, client: Any, model: str, prompts_dir: Path, temperature: float = 0.0):
+        self._client = client
+        self._model = model
+        self._system = geo_eval._read_text(prompts_dir / "ranker_system.txt")
+        self._user = geo_eval._read_text(prompts_dir / "ranker_user.txt")
+        self._temperature = temperature
+
+    def rank(self, query: str, candidates: Sequence[Candidate]) -> RankResult:
+        ordered = geo_eval._rank_candidates(
+            client=self._client,
+            model=self._model,
+            system_prompt=self._system,
+            user_template=self._user,
+            query=query,
+            candidates=candidates,
+            temperature=self._temperature,
+        )
+        return RankResult(query=query, ordered_ids=list(ordered))
+
+
+class Rewriter:
+    """Optimize a description by delegating to ``geo_eval._rewrite_description``."""
+
+    def __init__(self, *, client: Any, model: str, prompts_dir: Path, temperature: float = 0.0):
+        self._client = client
+        self._model = model
+        self._system = geo_eval._read_text(prompts_dir / "rewriter_system.txt")
+        self._user = geo_eval._read_text(prompts_dir / "rewriter_user.txt")
+        self._temperature = temperature
+
+    def rewrite(self, title: str, description: str) -> RewriteResult:
+        rewritten = geo_eval._rewrite_description(
+            client=self._client,
+            model=self._model,
+            system_prompt=self._system,
+            user_template=self._user,
+            title=title,
+            description=description,
+            temperature=self._temperature,
+        )
+        return RewriteResult(
+            title=title,
+            original_description=description,
+            rewritten_description=rewritten,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Indexer (deterministic, offline)
+# --------------------------------------------------------------------------- #
+
+
+class Indexer:
+    """Generate JSON-LD schema by filling a template shipped in ``geo-output/schema``.
+
+    This mirrors the Claude ``geo-indexer`` agent's job but is deterministic and
+    offline. Known ``name``/``description`` fields are filled; remaining
+    ``[FILL: ...]`` placeholders are left intact so users complete them. The
+    output still passes ``scripts/validate_jsonld.py``.
+    """
+
+    # Map a logical content type to a shipped template file.
+    _TEMPLATE_BY_TYPE = {
+        "Organization": "Organization.json",
+        "Product": "Product.json",
+        "Service": "Service.json",
+        "Article": "Article.json",
+        "FAQPage": "FAQPage.json",
+    }
+
+    def __init__(self, *, schema_dir: Path):
+        self._schema_dir = schema_dir
+
+    def available_types(self) -> List[str]:
+        return [t for t, f in self._TEMPLATE_BY_TYPE.items() if (self._schema_dir / f).exists()]
+
+    def generate_schema(self, *, schema_type: str, name: str, description: str) -> SchemaResult:
+        filename = self._TEMPLATE_BY_TYPE.get(schema_type)
+        if not filename:
+            raise ValueError(
+                f"Unknown schema type '{schema_type}'. Known: {sorted(self._TEMPLATE_BY_TYPE)}"
+            )
+        template_path = self._schema_dir / filename
+        doc: Dict[str, Any] = json.loads(template_path.read_text(encoding="utf-8"))
+
+        # Fill the two fields we can confidently populate from the pipeline.
+        name_key = "headline" if schema_type == "Article" else "name"
+        if name_key in doc:
+            doc[name_key] = name
+        if "description" in doc:
+            doc["description"] = description
+
+        return SchemaResult(schema_type=schema_type, json_ld=doc)

--- a/egeo/cli.py
+++ b/egeo/cli.py
@@ -1,0 +1,217 @@
+"""The standalone ``egeo`` command-line interface.
+
+Runtime-agnostic entry point for the GEO pipeline. Subcommands:
+
+- ``optimize <file>``     analyze → rank → rewrite → index a local file.
+- ``evaluate``            thin wrapper over ``geo_eval.evaluate``.
+- ``optimize-prompts``    thin wrapper over ``geo_eval.optimize`` (meta-optimizer).
+- ``runtimes``            list available runtimes and their status.
+
+Everything honors ``GEO_EVAL_MOCK=1`` (via ``llm_client.get_client``), so the
+CLI runs offline in CI without an API key.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from . import __version__, repo_root
+
+_DEFAULT_PROMPTS = str(repo_root() / "prompts")
+
+
+def _add_evaluate_parser(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("evaluate", help="Evaluate prompt quality on a dataset (wraps geo_eval.evaluate).")
+    p.add_argument("--dataset", required=True)
+    p.add_argument("--prompts", default=_DEFAULT_PROMPTS)
+    p.add_argument("--ranker-model", default=os.environ.get("RANKER_MODEL", "gpt-4o"))
+    p.add_argument("--rewriter-model", default=os.environ.get("REWRITER_MODEL", "gpt-4o"))
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--limit", type=int, default=None)
+    p.add_argument("--verbose", action="store_true")
+
+
+def _add_optimize_prompts_parser(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "optimize-prompts",
+        help="Meta-optimize the rewriter prompt (wraps geo_eval.optimize; non-destructive by default).",
+    )
+    p.add_argument("--train", required=True)
+    p.add_argument("--val", required=True)
+    p.add_argument("--prompts", default=_DEFAULT_PROMPTS)
+    p.add_argument("--ranker-model", default=os.environ.get("RANKER_MODEL", "gpt-4o"))
+    p.add_argument("--rewriter-model", default=os.environ.get("REWRITER_MODEL", "gpt-4o"))
+    p.add_argument("--meta-model", default=os.environ.get("META_MODEL", "gpt-4o"))
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--seed", type=int, default=7)
+    p.add_argument("--iters", type=int, default=5)
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Overwrite the working rewriter prompt in place (default: write *.candidate.txt).",
+    )
+
+
+def _add_optimize_parser(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("optimize", help="Run the GEO pipeline on a local content file.")
+    p.add_argument("input", help="Path to a local content file (Markdown/text).")
+    p.add_argument("--out-dir", default="geo-output", help="Output directory (default: geo-output).")
+    p.add_argument("--query", default=None, help="Search query to rank against (default: derived from the title).")
+    p.add_argument(
+        "--schema-type",
+        default="Article",
+        choices=["Organization", "Product", "Service", "Article", "FAQPage"],
+        help="JSON-LD schema template to emit (default: Article).",
+    )
+    p.add_argument("--runtime", default="python", help="Runtime to use (default: python).")
+    p.add_argument("--ranker-model", default=os.environ.get("RANKER_MODEL", "gpt-4o"))
+    p.add_argument("--rewriter-model", default=os.environ.get("REWRITER_MODEL", "gpt-4o"))
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--json", action="store_true", help="Print only the machine-readable JSON summary.")
+
+
+def _add_runtimes_parser(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser("runtimes", help="List available runtimes and their status.")
+    p.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    import geo_eval
+
+    summary = geo_eval.evaluate(
+        dataset_path=Path(args.dataset),
+        prompts_dir=Path(args.prompts),
+        ranker_model=args.ranker_model,
+        rewriter_model=args.rewriter_model,
+        temperature=args.temperature,
+        seed=args.seed,
+        limit=args.limit,
+        verbose=args.verbose,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_optimize_prompts(args: argparse.Namespace) -> int:
+    import geo_eval
+
+    res = geo_eval.optimize(
+        train_path=Path(args.train),
+        val_path=Path(args.val),
+        prompts_dir=Path(args.prompts),
+        ranker_model=args.ranker_model,
+        rewriter_model=args.rewriter_model,
+        meta_model=args.meta_model,
+        temperature=args.temperature,
+        seed=args.seed,
+        iters=args.iters,
+        apply=args.apply,
+    )
+    print(json.dumps(res, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_optimize(args: argparse.Namespace) -> int:
+    from .pipeline import optimize_content
+    from .runtimes import get_runtime
+
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        print(f"ERROR: input file not found: {input_path}", file=sys.stderr)
+        return 1
+
+    content = input_path.read_text(encoding="utf-8")
+    runtime = get_runtime(
+        args.runtime,
+        ranker_model=args.ranker_model,
+        rewriter_model=args.rewriter_model,
+        temperature=args.temperature,
+    )
+    if not runtime.executes_in_process:
+        print(
+            f"ERROR: runtime '{runtime.name}' does not execute in-process. "
+            f"Use --runtime python, or run the pipeline inside Claude Code.",
+            file=sys.stderr,
+        )
+        return 2
+
+    result = optimize_content(
+        runtime=runtime,
+        content=content,
+        source=str(input_path),
+        output_dir=Path(args.out_dir),
+        query=args.query,
+        schema_type=args.schema_type,
+    )
+
+    if args.json:
+        print(json.dumps(result.summary(), indent=2, sort_keys=True))
+        return 0
+
+    delta = result.rank_improvement
+    delta_str = f"+{delta}" if delta > 0 else str(delta)
+    print(f"✓ Optimized: {result.title}")
+    print(f"  Runtime:     {result.runtime}")
+    print(f"  GEO score:   {result.analysis.total_score}/100")
+    print(f"  Rank:        #{result.rank_before} → #{result.rank_after} ({delta_str})")
+    print(f"  Output dir:  {result.output_dir}")
+    for path in result.written_files:
+        print(f"   - {path}")
+    return 0
+
+
+def _cmd_runtimes(args: argparse.Namespace) -> int:
+    from .runtimes import runtime_status
+
+    infos = runtime_status()
+    if args.json:
+        print(json.dumps([info.__dict__ for info in infos], indent=2, sort_keys=True))
+        return 0
+
+    print("Supported runtimes:\n")
+    for info in infos:
+        status = "available" if info.available else "unavailable"
+        mode = "in-process" if info.executes_in_process else "host-executed"
+        aliases = f" (aliases: {', '.join(info.aliases)})" if info.aliases else ""
+        print(f"• {info.name}{aliases}")
+        print(f"    status: {status} | mode: {mode}")
+        print(f"    {info.description}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="egeo",
+        description="E-GEO: runtime-agnostic Generative Engine Optimization CLI.",
+    )
+    parser.add_argument("--version", action="version", version=f"egeo {__version__}")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    _add_optimize_parser(sub)
+    _add_evaluate_parser(sub)
+    _add_optimize_prompts_parser(sub)
+    _add_runtimes_parser(sub)
+    return parser
+
+
+_DISPATCH = {
+    "optimize": _cmd_optimize,
+    "evaluate": _cmd_evaluate,
+    "optimize-prompts": _cmd_optimize_prompts,
+    "runtimes": _cmd_runtimes,
+}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = _DISPATCH[args.cmd]
+    return handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/egeo/pipeline.py
+++ b/egeo/pipeline.py
@@ -1,0 +1,287 @@
+"""The runtime-agnostic ``optimize`` pipeline.
+
+Orchestrates the four agents for a single piece of content:
+
+    analyze → rank (before) → rewrite → rank (after) → index → write artifacts
+
+Ranking needs something to rank *against*. Because the offline runtime cannot
+ask an LLM to invent competitors, the pipeline ranks the target against a small
+set of deterministic, clearly-labeled generic competitor stubs. This keeps the
+pipeline runnable with no API key (and under ``GEO_EVAL_MOCK=1``) while still
+producing a before/after ranking signal.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from geo_eval import Candidate
+
+from .agents import AnalysisResult, RankResult, RewriteResult, SchemaResult
+from .runtimes import RuntimeAdapter
+
+__all__ = ["OptimizeResult", "optimize_content", "DEFAULT_COMPETITORS"]
+
+# Deterministic, generic competitor stubs. They are intentionally plausible but
+# synthetic; the report labels them as such. They never contain the "Best for"
+# intent marker, so a rewritten target reliably gains a ranking edge offline.
+DEFAULT_COMPETITORS: List[Dict[str, str]] = [
+    {
+        "id": "competitor_a",
+        "title": "Established Market Leader",
+        "description": (
+            "A widely-used option in this category with broad feature coverage, "
+            "long market presence, and a large existing customer base. Generalist "
+            "positioning that targets many segments at once rather than a specific use case."
+        ),
+    },
+    {
+        "id": "competitor_b",
+        "title": "Budget Alternative",
+        "description": (
+            "A low-cost entry-level alternative covering the basics. Limited depth, "
+            "minimal differentiation, and generic messaging aimed at price-sensitive buyers."
+        ),
+    },
+    {
+        "id": "competitor_c",
+        "title": "Niche Specialist",
+        "description": (
+            "A specialist tool focused on one narrow workflow. Strong in its niche "
+            "but with gaps outside it and a steeper learning curve for new users."
+        ),
+    },
+]
+
+_TARGET_ID = "target"
+
+
+@dataclass
+class OptimizeResult:
+    """Aggregated output of :func:`optimize_content`."""
+
+    source: str
+    title: str
+    runtime: str
+    analysis: AnalysisResult
+    query: str
+    rank_before: int
+    rank_after: int
+    rewrite: RewriteResult
+    schema: SchemaResult
+    output_dir: Path
+    written_files: List[Path]
+
+    @property
+    def rank_improvement(self) -> int:
+        return self.rank_before - self.rank_after
+
+    def summary(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "title": self.title,
+            "runtime": self.runtime,
+            "query": self.query,
+            "geo_score": self.analysis.total_score,
+            "rank_before": self.rank_before,
+            "rank_after": self.rank_after,
+            "rank_improvement": self.rank_improvement,
+            "output_dir": str(self.output_dir),
+            "written_files": [str(p) for p in self.written_files],
+        }
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "content"
+
+
+def _strip_frontmatter_keep(text: str) -> str:
+    m = re.match(r"^---\s*\n.*?\n---\s*(?:\n|$)", text, re.DOTALL)
+    if m:
+        return text[m.end():]
+    return text
+
+
+def _derive_title_and_body(content: str) -> tuple[str, str]:
+    body = _strip_frontmatter_keep(content)
+    lines = body.splitlines()
+    title = ""
+    body_start = 0
+    for i, ln in enumerate(lines):
+        if ln.strip().startswith("#"):
+            title = ln.lstrip("#").strip()
+            body_start = i + 1
+            break
+        if ln.strip():
+            title = ln.strip()
+            body_start = i + 1
+            break
+    description = "\n".join(lines[body_start:]).strip() or body.strip()
+    if not title:
+        title = "Untitled"
+    return title, description
+
+
+def _short_description(text: str, *, limit: int = 280) -> str:
+    flat = re.sub(r"\s+", " ", text).strip()
+    if len(flat) <= limit:
+        return flat
+    cut = flat[:limit]
+    last_period = cut.rfind(". ")
+    if last_period > 60:
+        return cut[: last_period + 1]
+    return cut.rstrip() + "…"
+
+
+def _build_report(result: "OptimizeResult") -> str:
+    a = result.analysis
+    score_rows = "\n".join(
+        f"| {feat.replace('_', ' ').title()} | {a.scores[feat]}/10 |" for feat in a.scores
+    )
+    gaps = "\n".join(f"- **{g['feature']}** — {g['recommendation']}" for g in a.gaps) or "- None 🎉"
+    strengths = "\n".join(f"- {s.replace('_', ' ').title()}" for s in a.strengths) or "- (none detected)"
+    actions = "\n".join(f"{i}. {act}" for i, act in enumerate(result.analysis.priority_actions, 1)) or "1. (none)"
+    delta = result.rank_improvement
+    delta_str = f"+{delta}" if delta > 0 else str(delta)
+
+    return f"""# 🎯 GEO Optimization Report
+
+- **Source:** `{result.source}`
+- **Title:** {result.title}
+- **Runtime:** `{result.runtime}`
+- **GEO Score:** {a.total_score}/100
+
+## Ranking Simulation
+
+Simulated against {len(DEFAULT_COMPETITORS)} generic competitor stubs (synthetic, for illustration).
+
+- **Query:** {result.query}
+- **Rank before optimization:** #{result.rank_before}
+- **Rank after optimization:** #{result.rank_after}
+- **Improvement:** {delta_str} position(s)
+
+## GEO Feature Scores
+
+| Feature | Score |
+|---------|-------|
+{score_rows}
+
+## Strengths
+
+{strengths}
+
+## Gaps & Recommendations
+
+{gaps}
+
+## Priority Actions
+
+{actions}
+
+## Outputs
+
+- `optimized/` — GEO-optimized content (copy-paste ready)
+- `schema/` — JSON-LD markup (`{result.schema.schema_type}`)
+- `analysis.json` — raw analysis data
+
+> **Honest scope:** competitor stubs and the analyzer score are an offline
+> proxy, not a measurement of real AI-engine rankings. Use the Claude Code
+> runtime with MCP validation, or the evaluation harness, for higher fidelity.
+"""
+
+
+def optimize_content(
+    *,
+    runtime: RuntimeAdapter,
+    content: str,
+    source: str,
+    output_dir: Path,
+    query: Optional[str] = None,
+    schema_type: str = "Article",
+) -> OptimizeResult:
+    """Run analyze → rank → rewrite → rank → index and write artifacts."""
+    title, description = _derive_title_and_body(content)
+    effective_query = query or f"best {title}".strip()
+
+    analyzer = runtime.make_analyzer()
+    ranker = runtime.make_ranker()
+    rewriter = runtime.make_rewriter()
+    indexer = runtime.make_indexer()
+
+    analysis = analyzer.analyze(content, title=title)
+
+    competitors = [Candidate(id=c["id"], title=c["title"], description=c["description"]) for c in DEFAULT_COMPETITORS]
+    target_before = Candidate(id=_TARGET_ID, title=title, description=description)
+    before = ranker.rank(effective_query, [target_before, *competitors])
+    rank_before = before.position_of(_TARGET_ID)
+
+    rewrite = rewriter.rewrite(title, description)
+
+    target_after = Candidate(id=_TARGET_ID, title=title, description=rewrite.rewritten_description)
+    after = ranker.rank(effective_query, [target_after, *competitors])
+    rank_after = after.position_of(_TARGET_ID)
+
+    schema = indexer.generate_schema(
+        schema_type=schema_type,
+        name=title,
+        description=_short_description(rewrite.rewritten_description),
+    )
+
+    # --- write artifacts --------------------------------------------------- #
+    output_dir = Path(output_dir)
+    slug = _slugify(title)
+    optimized_dir = output_dir / "optimized"
+    schema_out_dir = output_dir / "schema"
+    optimized_dir.mkdir(parents=True, exist_ok=True)
+    schema_out_dir.mkdir(parents=True, exist_ok=True)
+
+    written: List[Path] = []
+
+    optimized_path = optimized_dir / f"{slug}.md"
+    optimized_path.write_text(
+        f"# {title}\n\n{rewrite.rewritten_description}\n", encoding="utf-8"
+    )
+    written.append(optimized_path)
+
+    schema_path = schema_out_dir / f"{slug}.json"
+    schema_path.write_text(schema.to_json() + "\n", encoding="utf-8")
+    written.append(schema_path)
+
+    analysis_path = output_dir / "analysis.json"
+    analysis_payload = {
+        "source": source,
+        "title": title,
+        "runtime": runtime.name,
+        "query": effective_query,
+        "rank_before": rank_before,
+        "rank_after": rank_after,
+        "rank_improvement": rank_before - rank_after,
+        "analysis": analysis.to_dict(),
+    }
+    analysis_path.write_text(json.dumps(analysis_payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    written.append(analysis_path)
+
+    result = OptimizeResult(
+        source=source,
+        title=title,
+        runtime=runtime.name,
+        analysis=analysis,
+        query=effective_query,
+        rank_before=rank_before,
+        rank_after=rank_after,
+        rewrite=rewrite,
+        schema=schema,
+        output_dir=output_dir,
+        written_files=written,
+    )
+
+    report_path = output_dir / "report.md"
+    report_path.write_text(_build_report(result), encoding="utf-8")
+    written.insert(0, report_path)
+    result.written_files = written
+
+    return result

--- a/egeo/runtimes.py
+++ b/egeo/runtimes.py
@@ -1,0 +1,241 @@
+"""Runtime adapter layer.
+
+The four-agent contract (Analyzer, Ranker, Rewriter, Indexer) is defined once in
+:mod:`egeo.agents`. This module lets multiple *runtimes* supply implementations
+of that contract:
+
+- :class:`PythonRuntime` (``python`` / ``cli``) runs the agents in-process using
+  ``llm_client.get_client()`` and the ``prompts/`` templates. This is the
+  runtime the standalone ``egeo`` CLI uses.
+- :class:`ClaudeCodeRuntime` (``claude-code``) is a *descriptor*: it maps each
+  agent to its ``.claude/agents/*.md`` definition and slash command. Claude Code
+  itself executes those; attempting to run them in-process raises a clear error.
+
+A tiny registry (:func:`get_runtime`, :func:`list_runtimes`) exposes the known
+runtimes to the CLI (``egeo runtimes``).
+"""
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import repo_root
+from .agents import Analyzer, Indexer, Ranker, Rewriter
+
+__all__ = [
+    "RuntimeAdapter",
+    "PythonRuntime",
+    "ClaudeCodeRuntime",
+    "RuntimeUnsupportedError",
+    "RuntimeInfo",
+    "get_runtime",
+    "list_runtimes",
+    "runtime_status",
+]
+
+
+class RuntimeUnsupportedError(RuntimeError):
+    """Raised when an agent cannot be executed in-process by a given runtime."""
+
+
+@dataclass
+class RuntimeInfo:
+    name: str
+    aliases: List[str]
+    description: str
+    available: bool
+    executes_in_process: bool
+
+
+class RuntimeAdapter(ABC):
+    """Contract every runtime adapter implements.
+
+    A runtime is a factory for the four agents plus metadata used by
+    ``egeo runtimes``. Concrete runtimes either execute the agents in-process
+    (``executes_in_process = True``) or merely describe how a host runtime runs
+    them (``executes_in_process = False``).
+    """
+
+    name: str = "base"
+    aliases: List[str] = []
+    description: str = ""
+    executes_in_process: bool = False
+
+    def __init__(self, *, root: Optional[Path] = None):
+        self.root = root or repo_root()
+
+    # --- discovery ---------------------------------------------------------- #
+
+    @abstractmethod
+    def available(self) -> bool:
+        """Whether this runtime can be used in the current environment."""
+
+    def info(self) -> RuntimeInfo:
+        return RuntimeInfo(
+            name=self.name,
+            aliases=list(self.aliases),
+            description=self.description,
+            available=self.available(),
+            executes_in_process=self.executes_in_process,
+        )
+
+    # --- agent factories ---------------------------------------------------- #
+
+    @abstractmethod
+    def make_analyzer(self) -> Analyzer: ...
+
+    @abstractmethod
+    def make_ranker(self) -> Ranker: ...
+
+    @abstractmethod
+    def make_rewriter(self) -> Rewriter: ...
+
+    @abstractmethod
+    def make_indexer(self) -> Indexer: ...
+
+
+class PythonRuntime(RuntimeAdapter):
+    """In-process runtime backed by ``llm_client`` and the ``prompts/`` templates.
+
+    The Ranker and Rewriter use the client returned by ``llm_client.get_client()``
+    — which honors ``GEO_EVAL_MOCK=1`` — so this runtime works fully offline in
+    CI. The Analyzer and Indexer are deterministic and never touch the network.
+    """
+
+    name = "python"
+    aliases = ["cli", "local"]
+    description = "In-process Python runtime used by the `egeo` CLI (honors GEO_EVAL_MOCK)."
+    executes_in_process = True
+
+    def __init__(
+        self,
+        *,
+        root: Optional[Path] = None,
+        ranker_model: Optional[str] = None,
+        rewriter_model: Optional[str] = None,
+        temperature: float = 0.0,
+    ):
+        super().__init__(root=root)
+        self.prompts_dir = self.root / "prompts"
+        self.schema_dir = self.root / "geo-output" / "schema"
+        self.ranker_model = ranker_model or os.environ.get("RANKER_MODEL", "gpt-4o")
+        self.rewriter_model = rewriter_model or os.environ.get("REWRITER_MODEL", "gpt-4o")
+        self.temperature = temperature
+
+    def available(self) -> bool:
+        return self.prompts_dir.is_dir()
+
+    def _client(self) -> Any:
+        # Imported lazily so the package can be imported without configuring a
+        # client (e.g. for `egeo runtimes`).
+        import llm_client
+
+        return llm_client.get_client()
+
+    def make_analyzer(self) -> Analyzer:
+        return Analyzer()
+
+    def make_ranker(self) -> Ranker:
+        return Ranker(
+            client=self._client(),
+            model=self.ranker_model,
+            prompts_dir=self.prompts_dir,
+            temperature=self.temperature,
+        )
+
+    def make_rewriter(self) -> Rewriter:
+        return Rewriter(
+            client=self._client(),
+            model=self.rewriter_model,
+            prompts_dir=self.prompts_dir,
+            temperature=self.temperature,
+        )
+
+    def make_indexer(self) -> Indexer:
+        return Indexer(schema_dir=self.schema_dir)
+
+
+class ClaudeCodeRuntime(RuntimeAdapter):
+    """Descriptor adapter for the Claude Code host.
+
+    Claude Code executes the agents from their ``.claude/agents/*.md``
+    definitions via slash commands (``/geo``, ``/geo:audit`` ...). Python cannot
+    drive Claude Code, so the agent factories raise a helpful error pointing the
+    user at the slash-command entry point. This adapter exists to (a) make the
+    runtime discoverable via ``egeo runtimes`` and (b) document the mapping
+    between the contract and the Claude Code artifacts.
+    """
+
+    name = "claude-code"
+    aliases = ["claude"]
+    description = "Claude Code host runtime (executes .claude/ agents via /geo slash commands)."
+    executes_in_process = False
+
+    #: Maps each agent to its Claude Code definition + the slash command that runs it.
+    AGENT_MAP: Dict[str, Dict[str, str]] = {
+        "analyzer": {"definition": ".claude/agents/geo-analyzer.md", "command": "/geo:audit"},
+        "ranker": {"definition": ".claude/agents/geo-ranker.md", "command": "/geo"},
+        "rewriter": {"definition": ".claude/agents/geo-rewriter.md", "command": "/geo:optimize"},
+        "indexer": {"definition": ".claude/agents/geo-indexer.md", "command": "/geo"},
+    }
+
+    def available(self) -> bool:
+        return (self.root / ".claude").is_dir()
+
+    def _unsupported(self, agent: str) -> "RuntimeUnsupportedError":
+        meta = self.AGENT_MAP[agent]
+        return RuntimeUnsupportedError(
+            f"The '{self.name}' runtime does not execute the {agent} agent in-process. "
+            f"Run it inside Claude Code using '{meta['command']}' "
+            f"(definition: {meta['definition']}). For an in-process pipeline use the "
+            f"'python' runtime, e.g. `egeo optimize <file>`."
+        )
+
+    def make_analyzer(self) -> Analyzer:
+        raise self._unsupported("analyzer")
+
+    def make_ranker(self) -> Ranker:
+        raise self._unsupported("ranker")
+
+    def make_rewriter(self) -> Rewriter:
+        raise self._unsupported("rewriter")
+
+    def make_indexer(self) -> Indexer:
+        raise self._unsupported("indexer")
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+_RUNTIME_CLASSES = [PythonRuntime, ClaudeCodeRuntime]
+
+
+def _resolve_class(name: str):
+    key = (name or "").strip().lower()
+    for cls in _RUNTIME_CLASSES:
+        if key == cls.name or key in cls.aliases:
+            return cls
+    raise ValueError(
+        f"Unknown runtime '{name}'. Known: "
+        + ", ".join(c.name for c in _RUNTIME_CLASSES)
+    )
+
+
+def get_runtime(name: str = "python", **kwargs: Any) -> RuntimeAdapter:
+    """Return a runtime adapter by name or alias (default: ``python``)."""
+    cls = _resolve_class(name)
+    return cls(**kwargs)
+
+
+def list_runtimes(**kwargs: Any) -> List[RuntimeAdapter]:
+    """Instantiate every known runtime adapter."""
+    return [cls(**kwargs) for cls in _RUNTIME_CLASSES]
+
+
+def runtime_status(**kwargs: Any) -> List[RuntimeInfo]:
+    """Return :class:`RuntimeInfo` for every known runtime (used by ``egeo runtimes``)."""
+    return [rt.info() for rt in list_runtimes(**kwargs)]

--- a/openspec/changes/add-runtime-adapters/design.md
+++ b/openspec/changes/add-runtime-adapters/design.md
@@ -1,0 +1,140 @@
+# Design: Runtime Adapter Layer and `egeo` CLI
+
+## Context
+
+E-GEO's four agents (Analyzer, Ranker, Rewriter, Indexer) are defined only as
+Claude Code artifacts: `.claude/agents/*.md` prompts and `.claude/commands/*.md`
+slash commands. The repository topics advertise `cursor`, `codex`, and
+`windsurf`, but none of those runtimes can execute the pipeline — the agent
+*logic* is welded to the Claude Code *runtime*.
+
+Meanwhile, the Python harness already contains runtime-neutral building blocks:
+`geo_eval._rank_candidates` and `geo_eval._rewrite_description` drive the ranker
+and rewriter via `prompts/*.txt` and a pluggable `llm_client.get_client()` that
+already supports an offline `MockClient` (`GEO_EVAL_MOCK=1`).
+
+**Stakeholders:** maintainers (one contract to maintain), non-Claude users
+(a real entry point), and evaluators (an honest, reproducible offline path).
+
+**Constraints:** reuse `geo_eval.py`/`llm_client.py` (do not fork their logic),
+keep dependencies tiny (no new runtime deps beyond the stdlib for the CLI),
+preserve all existing CI gates, and keep the offline `GEO_EVAL_MOCK=1` path
+working end-to-end.
+
+## Goals / Non-Goals
+
+### Goals
+- Define the four-agent contract **once**, decoupled from any runtime.
+- Ship a standalone `egeo` CLI that runs the pipeline outside Claude Code.
+- Reuse the existing ranker/rewriter logic and prompts verbatim.
+- Keep everything runnable offline in CI via the MOCK client.
+- Automate GitHub Releases from `CHANGELOG.md` on `v*` tags.
+
+### Non-Goals
+- Re-implementing Claude Code's orchestration in Python (the `claude-code`
+  runtime stays a descriptor; Claude Code still executes it).
+- Live web scraping / MCP validation in the CLI (the CLI optimizes local files
+  and uses deterministic competitor stubs; MCP-backed validation remains a
+  Claude Code feature).
+- Changing prompt contents or the `geo_eval` metrics.
+
+## Decisions
+
+### 1. A four-agent contract with pluggable runtimes
+
+**Decision:** `egeo/runtimes.py` defines a `RuntimeAdapter` base class with
+factory methods `make_analyzer/ranker/rewriter/indexer()` plus `name` and
+`available()`. Two adapters implement it:
+
+| Runtime | `name` | Agents execute… | `available()` |
+|---------|--------|-----------------|---------------|
+| Python/CLI | `python` (alias `cli`) | in-process via `llm_client` + `prompts/` | always |
+| Claude Code | `claude-code` | in the Claude Code host (descriptor only) | `.claude/` exists |
+
+`ClaudeCodeRuntime` exposes the file path and slash command for each agent and
+raises a clear "run via Claude Code (`/geo`)" error if a caller tries to invoke
+it in-process. This makes the separation explicit without pretending Python can
+drive Claude Code.
+
+**Alternatives considered:**
+- *One monolithic CLI with no adapter layer*: rejected — it would re-entangle
+  agent logic with a single runtime and not address the multi-runtime promise.
+- *A plugin/entry-point system*: rejected as premature; two adapters and a small
+  registry are enough today.
+
+### 2. Reuse `geo_eval` for Ranker and Rewriter
+
+**Decision:** `Ranker.rank()` calls `geo_eval._rank_candidates(...)` and
+`Rewriter.rewrite()` calls `geo_eval._rewrite_description(...)`, passing the
+prompts loaded from `prompts/`. The agents are thin adapters over these
+functions, so the CLI and the harness share one code path and one set of
+prompts.
+
+**Rationale:** zero logic duplication; the MOCK client already understands these
+prompts, so the CLI inherits the offline behavior for free.
+
+### 3. Deterministic, offline Analyzer and Indexer
+
+**Decision:** The Analyzer scores the 10 GEO features with a transparent keyword
+/ structure heuristic (no LLM). The Indexer loads a template from
+`geo-output/schema/` and fills `name`/`description`, leaving `[FILL: ...]`
+placeholders intact so the emitted schema still passes `validate_jsonld.py`.
+
+**Rationale:** keeps `egeo optimize` runnable with no API key and makes the
+report deterministic for CI. Heuristic scoring is honest about being a proxy and
+mirrors the signals the Claude analyzer prompt looks for.
+
+### 4. `optimize` pipeline with built-in competitor stubs
+
+**Decision:** `egeo/pipeline.py` runs analyze → rank(before) → rewrite →
+rank(after) → index for a single input. Because the offline runtime cannot ask
+an LLM to invent competitors, the pipeline ranks the target against a small set
+of deterministic generic competitor stubs, yielding a before/after rank delta.
+Artifacts: `report.md`, `analysis.json`, `optimized/<name>.md`,
+`schema/<name>.json`.
+
+### 5. Packaging: console script + `python -m egeo`
+
+**Decision:** Add `pyproject.toml` declaring the `egeo` package, the root
+modules `geo_eval`/`llm_client` as py-modules, and a console script
+`egeo = "egeo.cli:main"`. `egeo/__init__.py` also bootstraps `sys.path` with the
+repo root, so `python -m egeo` works without installation. CI uses
+`python -m egeo` to avoid an install step.
+
+### 6. Release automation from CHANGELOG
+
+**Decision:** `.github/workflows/release.yml` triggers on `v*` tags and
+`workflow_dispatch`. It resolves the tag, extracts the matching
+`## [VERSION]` section from `CHANGELOG.md` with `awk`, and publishes via
+`gh release create --verify-tag --latest` (falling back to `gh release edit`).
+`permissions: contents: write` is required to create releases.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Heuristic analyzer diverges from the Claude analyzer | Documented as an offline proxy; the Claude runtime remains the high-fidelity path. |
+| Competitor stubs are synthetic | Clearly labeled in the report; users can supply real competitors via the harness dataset. |
+| `claude-code` runtime can't run in Python | By design — it is a descriptor; calling it in-process raises a helpful error. |
+| Editable install exposing root modules | Scoped via explicit `py-modules`; `python -m egeo` path needs no install. |
+| Release workflow needs write permission | `permissions: contents: write` set at the workflow level only. |
+
+## Migration Plan
+
+1. Land the `egeo/` package, `pyproject.toml`, CI smoke step, release workflow,
+   and docs on `release/v2.0-runtime-adapters`.
+2. Verify CI green (existing gates + new CLI smoke) on the PR.
+3. After merge, finalize the `[Unreleased]` CHANGELOG section as `v2.0.0` and
+   tag `v2.0.0` to exercise `release.yml`.
+
+Rollback: the change is additive. Removing `egeo/`, `pyproject.toml`, the CI
+smoke step, and `release.yml` restores prior behavior; `geo_eval.py` and
+`llm_client.py` are untouched.
+
+## Open Questions
+
+- Should `egeo optimize` gain a `--competitors <file>` flag to supply real
+  candidates instead of stubs? (Deferred to a future change.)
+- Should additional descriptor runtimes (`cursor`, `windsurf`) ship generated
+  rule files, or is documenting the `python` CLI entry point sufficient for
+  now? (Deferred; the CLI already unblocks those runtimes.)

--- a/openspec/changes/add-runtime-adapters/proposal.md
+++ b/openspec/changes/add-runtime-adapters/proposal.md
@@ -1,0 +1,94 @@
+# Change: Add a Runtime Adapter Layer and a Standalone `egeo` CLI
+
+## Why
+
+E-GEO advertises broad runtime support — the repository topics include
+`claude-code`, `cursor`, `codex`, and `windsurf` — but the product is only
+actually executable inside **Claude Code**. The four agents (Analyzer, Ranker,
+Rewriter, Indexer) exist solely as Claude-Code-specific definitions in
+`.claude/agents/*.md`, the pipeline is a set of Claude slash commands
+(`.claude/commands/*.md`), and the only thing a non-Claude user can run is the
+low-level evaluation harness (`geo_eval.py`).
+
+This creates three problems:
+
+- **The multi-runtime promise is unmet.** Cursor/Codex/Windsurf users who
+  install the repo (or `npx skills add ...`) get agent prompts they cannot
+  execute as a pipeline. The agent *logic* is entangled with the Claude Code
+  *runtime*.
+- **No runtime-agnostic entry point.** There is no way to run "optimize this
+  file" outside Claude Code, even though the building blocks (the ranker and
+  rewriter prompts plus `llm_client.py`) are already runtime-neutral Python.
+- **The harness is hard to discover.** `geo_eval.py evaluate/optimize` is
+  powerful but undocumented as a product surface; new users do not know it
+  exists or how the commands map to the agents.
+
+## What Changes
+
+- Add a **runtime adapter abstraction** (`egeo/runtimes.py`) that defines the
+  four-agent contract once and lets concrete runtimes plug in implementations:
+  - `python` (a.k.a. `cli`) — runs the agents in-process using `llm_client.py`
+    and the prompts in `prompts/`. This is the runtime the CLI uses.
+  - `claude-code` — a descriptor adapter that points at the existing
+    `.claude/` agent definitions and slash commands; it documents the mapping
+    and is executed by the Claude Code host, not in Python.
+- Add **runtime-agnostic agent abstractions** (`egeo/agents.py`) for Analyzer,
+  Ranker, Rewriter, and Indexer. Ranker and Rewriter **reuse** the existing
+  `geo_eval._rank_candidates` / `geo_eval._rewrite_description` functions and
+  the `prompts/` templates — no logic is duplicated. Analyzer and Indexer are
+  deterministic, offline implementations (heuristic GEO scoring + JSON-LD
+  template filling) so the pipeline runs without an API key.
+- Add a standalone **`egeo` CLI** (`egeo/cli.py`, runnable as `egeo` or
+  `python -m egeo`) exposing:
+  - `egeo optimize <file>` — run the analyze → rank → rewrite → index pipeline
+    and write `geo-output/` artifacts.
+  - `egeo evaluate` — thin wrapper over `geo_eval.evaluate`.
+  - `egeo optimize-prompts` — thin wrapper over `geo_eval.optimize`
+    (the meta-optimizer; non-destructive by default).
+  - `egeo runtimes` — list available runtimes and their status.
+- The CLI honors **`GEO_EVAL_MOCK=1`** end-to-end (via the shared
+  `llm_client.get_client()`), so it runs offline in CI with no secrets.
+- Add a minimal `pyproject.toml` exposing the `egeo` console script (editable
+  install) while keeping `python -m egeo` working without installation.
+- **CI:** add a CLI smoke-test step to `.github/workflows/ci.yml`
+  (`GEO_EVAL_MOCK=1 python -m egeo ...`) without changing existing gates.
+- **Release automation:** add `.github/workflows/release.yml` that publishes a
+  GitHub Release from `CHANGELOG.md` on `v*` tags (and via `workflow_dispatch`).
+- **Docs:** add a "Supported Runtimes" section and CLI usage to `README.md`;
+  add an `[Unreleased]` entry to `CHANGELOG.md`.
+
+## Impact
+
+### Affected specs
+
+- New capability: `runtime-adapters`.
+
+### Affected files (planned implementation)
+
+- `egeo/__init__.py`, `egeo/__main__.py`, `egeo/agents.py`, `egeo/runtimes.py`,
+  `egeo/pipeline.py`, `egeo/cli.py` (new package)
+- `pyproject.toml` (new; console script `egeo`)
+- `geo_eval.py`, `llm_client.py` (reused, not modified)
+- `.github/workflows/ci.yml` (add CLI smoke step)
+- `.github/workflows/release.yml` (new)
+- `README.md` ("Supported Runtimes" + CLI usage)
+- `CHANGELOG.md` (`[Unreleased]` entry)
+
+### External systems
+
+- GitHub Actions (CI smoke step + Release workflow)
+- OpenAI-compatible API (real runs only; CI uses the MOCK client)
+
+### Success criteria
+
+- `GEO_EVAL_MOCK=1 python -m egeo optimize examples/sample-input.md` completes
+  offline and writes a report, optimized content, and a JSON-LD schema file.
+- `GEO_EVAL_MOCK=1 python -m egeo evaluate --dataset eval/datasets/geo_smoke.jsonl --limit 3`
+  prints a summary with `avg_rank_improvement`, `win_rate`, and
+  `stderr_rank_improvement` (identical numbers to `geo_eval.py evaluate`).
+- `egeo runtimes` lists `python` (available) and `claude-code` (available when a
+  `.claude/` directory is present).
+- The Ranker and Rewriter agents call into `geo_eval` — no ranking/rewriting
+  logic is re-implemented in `egeo/`.
+- Pushing a `v*` tag publishes a GitHub Release whose body is the matching
+  `CHANGELOG.md` section.

--- a/openspec/changes/add-runtime-adapters/specs/runtime-adapters/spec.md
+++ b/openspec/changes/add-runtime-adapters/specs/runtime-adapters/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Runtime-Agnostic Agent Contract
+The system SHALL define the four GEO agents (Analyzer, Ranker, Rewriter, Indexer) as a runtime-agnostic contract that is independent of any specific host runtime.
+
+#### Scenario: Agents are defined once and shared across runtimes
+- **WHEN** a runtime adapter is asked to construct the Analyzer, Ranker, Rewriter, or Indexer
+- **THEN** every adapter returns an object implementing the same agent contract
+- **AND** the Ranker and Rewriter agents delegate to the existing `geo_eval` ranking and rewriting functions rather than re-implementing them
+
+#### Scenario: Ranker and Rewriter reuse the shared prompts and harness
+- **WHEN** the Ranker ranks candidates or the Rewriter rewrites a description
+- **THEN** it uses the templates in `prompts/` and the client returned by `llm_client.get_client()`
+- **AND** no ranking or rewriting logic is duplicated outside `geo_eval.py`
+
+### Requirement: Pluggable Runtime Adapters
+The system SHALL provide a runtime adapter layer with a registry so that multiple runtimes can supply implementations of the four-agent contract.
+
+#### Scenario: Python runtime executes the agents in-process
+- **WHEN** the `python` (alias `cli`) runtime is selected
+- **THEN** the agents execute in-process using `llm_client` and the `prompts/` templates
+- **AND** the runtime reports itself as available
+
+#### Scenario: Claude Code runtime is a host-executed descriptor
+- **WHEN** the `claude-code` runtime is selected
+- **THEN** it maps each agent to its `.claude/agents/*.md` definition and slash command
+- **AND** it reports itself available only when a `.claude/` directory is present
+- **AND** attempting to execute one of its agents in-process raises a clear error directing the user to run it via Claude Code
+
+#### Scenario: Runtimes are discoverable through a registry
+- **WHEN** `list_runtimes()` is called or `egeo runtimes` is run
+- **THEN** the known runtimes are returned with their names and availability status
+
+### Requirement: Standalone `egeo` CLI
+The project SHALL provide a standalone `egeo` command, runnable as `egeo` or `python -m egeo`, exposing the GEO pipeline outside Claude Code.
+
+#### Scenario: Optimize a local file end-to-end
+- **WHEN** a user runs `egeo optimize <file>`
+- **THEN** the analyze → rank → rewrite → index pipeline runs against the file
+- **AND** `report.md`, `analysis.json`, an optimized content file, and a JSON-LD schema file are written to the output directory
+
+#### Scenario: Evaluate mirrors the harness
+- **WHEN** a user runs `egeo evaluate --dataset <path> [--limit N]`
+- **THEN** the command delegates to `geo_eval.evaluate`
+- **AND** prints a summary containing `avg_rank_improvement`, `win_rate`, and `stderr_rank_improvement`
+
+#### Scenario: Optimize-prompts mirrors the meta-optimizer
+- **WHEN** a user runs `egeo optimize-prompts --train <path> --val <path>`
+- **THEN** the command delegates to `geo_eval.optimize`
+- **AND** it is non-destructive by default, writing to `prompts/rewriter_user.candidate.txt` unless `--apply` is passed
+
+#### Scenario: List runtimes
+- **WHEN** a user runs `egeo runtimes`
+- **THEN** the CLI lists `python` and `claude-code` with their availability
+
+### Requirement: Offline Deterministic CLI Execution
+The `egeo` CLI SHALL run end-to-end without network access or API keys when the mock client is enabled, so it can execute in CI.
+
+#### Scenario: Optimize runs offline under the mock client
+- **WHEN** `GEO_EVAL_MOCK=1 egeo optimize <file>` is run
+- **THEN** no outbound network request is made
+- **AND** the pipeline completes and writes its artifacts
+
+#### Scenario: Evaluate runs offline under the mock client
+- **WHEN** `GEO_EVAL_MOCK=1 egeo evaluate --dataset eval/datasets/geo_smoke.jsonl --limit 3` is run
+- **THEN** the command exits successfully and prints the metric summary
+
+#### Scenario: Emitted schema passes JSON-LD validation
+- **WHEN** the Indexer writes a JSON-LD schema file during `egeo optimize`
+- **THEN** the file passes `scripts/validate_jsonld.py`
+
+### Requirement: CI Smoke Test for the CLI
+Continuous integration SHALL exercise the `egeo` CLI on every push and pull request to protected branches using the mock client.
+
+#### Scenario: CLI smoke test runs in CI
+- **WHEN** CI runs on a pull request targeting `main` or a `release/**` branch
+- **THEN** it runs `python -m egeo optimize`, `python -m egeo evaluate`, and `python -m egeo runtimes` with `GEO_EVAL_MOCK=1`
+- **AND** a non-zero exit from any of those commands fails the build
+- **AND** the pre-existing quality gates remain unchanged
+
+### Requirement: Automated GitHub Release Publishing
+The repository SHALL publish a GitHub Release automatically when a version tag is pushed, sourcing the release notes from `CHANGELOG.md`.
+
+#### Scenario: Tag push publishes a release
+- **WHEN** a tag matching `v*` is pushed
+- **THEN** the release workflow resolves the tag, extracts the matching `## [VERSION]` section from `CHANGELOG.md`, and publishes a GitHub Release with those notes
+
+#### Scenario: Manual dispatch publishes a release
+- **WHEN** the workflow is triggered via `workflow_dispatch` with a `tag` input
+- **THEN** it publishes (or updates) the release for that tag
+
+#### Scenario: Missing changelog section falls back gracefully
+- **WHEN** `CHANGELOG.md` has no section for the released version
+- **THEN** the workflow uses an auto-generated notes placeholder instead of failing
+
+### Requirement: Documented Supported Runtimes and CLI Usage
+The project SHALL document which runtimes are supported and how to use the `egeo` CLI.
+
+#### Scenario: README documents runtimes and the CLI
+- **WHEN** a user reads `README.md`
+- **THEN** a "Supported Runtimes" section lists the supported runtimes and their status
+- **AND** CLI usage for `optimize`, `evaluate`, `optimize-prompts`, and `runtimes` (including the `GEO_EVAL_MOCK=1` offline path) is documented

--- a/openspec/changes/add-runtime-adapters/tasks.md
+++ b/openspec/changes/add-runtime-adapters/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: Add a Runtime Adapter Layer and a Standalone `egeo` CLI
+
+## 1. Runtime-Agnostic Agent Abstractions
+
+- [ ] 1.1 Create the `egeo/` package with a `sys.path` bootstrap so it can import
+      the root-level `geo_eval` and `llm_client` modules from any working dir.
+- [ ] 1.2 Add `egeo/agents.py` with dataclasses for agent I/O (`AnalysisResult`,
+      `RankResult`, `RewriteResult`, `SchemaResult`) and the four agents.
+- [ ] 1.3 Implement `Ranker.rank(...)` as a thin wrapper over
+      `geo_eval._rank_candidates` (reuse the `prompts/ranker_*.txt` templates).
+- [ ] 1.4 Implement `Rewriter.rewrite(...)` as a thin wrapper over
+      `geo_eval._rewrite_description` (reuse `prompts/rewriter_*.txt`).
+- [ ] 1.5 Implement `Analyzer.analyze(...)` as a deterministic, offline heuristic
+      scorer for the 10 GEO features (no LLM, no network).
+- [ ] 1.6 Implement `Indexer.generate_schema(...)` by loading a template from
+      `geo-output/schema/` and filling `name`/`description` (no network).
+
+## 2. Runtime Adapter Layer
+
+- [ ] 2.1 Add `egeo/runtimes.py` defining the `RuntimeAdapter` contract
+      (factory methods for the four agents + `name`/`available()`).
+- [ ] 2.2 Implement `PythonRuntime` (names `python`/`cli`) that builds the
+      in-process agents using `llm_client.get_client()` and `prompts/`.
+- [ ] 2.3 Implement `ClaudeCodeRuntime` (name `claude-code`) as a descriptor that
+      maps each agent to its `.claude/agents/*.md` file and slash command, and
+      reports `available()` based on the presence of a `.claude/` directory.
+- [ ] 2.4 Add a registry: `get_runtime(name)` and `list_runtimes()`.
+
+## 3. Optimize Pipeline
+
+- [ ] 3.1 Add `egeo/pipeline.py` orchestrating analyze → rank(before) →
+      rewrite → rank(after) → index for a single input file or string.
+- [ ] 3.2 Use a small set of deterministic built-in competitor stubs so ranking
+      has a baseline to compare against offline.
+- [ ] 3.3 Write artifacts to the output dir: `report.md`, `analysis.json`,
+      `optimized/<name>.md`, `schema/<name>.json`.
+
+## 4. CLI
+
+- [ ] 4.1 Add `egeo/cli.py` with subcommands `optimize`, `evaluate`,
+      `optimize-prompts`, and `runtimes`.
+- [ ] 4.2 Wire `evaluate` and `optimize-prompts` to `geo_eval.evaluate` /
+      `geo_eval.optimize` so behavior matches `geo_eval.py` exactly.
+- [ ] 4.3 Add `egeo/__main__.py` so `python -m egeo` works.
+- [ ] 4.4 Add `pyproject.toml` exposing the `egeo` console script.
+
+## 5. Continuous Integration
+
+- [ ] 5.1 Add a CLI smoke-test step to `.github/workflows/ci.yml` running
+      `python -m egeo optimize`, `evaluate`, and `runtimes` with `GEO_EVAL_MOCK=1`.
+- [ ] 5.2 Confirm the existing gates (validators, link check, mock evaluate)
+      are unchanged and still pass.
+
+## 6. Release Automation
+
+- [ ] 6.1 Add `.github/workflows/release.yml` triggered on `v*` tags and
+      `workflow_dispatch`, extracting notes from `CHANGELOG.md` and publishing a
+      GitHub Release via `gh release create`/`edit`.
+
+## 7. Documentation
+
+- [ ] 7.1 Add a "Supported Runtimes" section to `README.md` (matrix + status).
+- [ ] 7.2 Add CLI usage (`egeo optimize/evaluate/optimize-prompts/runtimes`,
+      including the `GEO_EVAL_MOCK=1` offline path) to `README.md`.
+- [ ] 7.3 Add an `[Unreleased]` entry to `CHANGELOG.md` summarizing the change.
+
+## 8. Validation
+
+- [ ] 8.1 Run `GEO_EVAL_MOCK=1 python -m egeo optimize examples/sample-input.md`
+      and confirm artifacts are written.
+- [ ] 8.2 Confirm `egeo evaluate` output matches `geo_eval.py evaluate` for the
+      same dataset/flags under the MOCK client.
+- [ ] 8.3 Confirm `validate_jsonld.py` passes on the schema the Indexer emits.
+- [ ] 8.4 Confirm a default `optimize-prompts` run does not modify
+      `prompts/rewriter_user.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "egeo"
+version = "2.0.0"
+description = "E-GEO: runtime-agnostic Generative Engine Optimization toolkit and CLI."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "Vera Badias" }]
+keywords = ["geo", "generative-engine-optimization", "ai-search", "llm", "cli"]
+dependencies = [
+  "pyyaml>=6.0",   # SKILL.md frontmatter parsing (scripts/validate_skills.py)
+  "jsonschema>=4.0", # JSON-LD envelope validation (scripts/validate_jsonld.py)
+]
+
+[project.scripts]
+# Exposes the standalone `egeo` command after `pip install -e .`.
+# `python -m egeo ...` also works without installation.
+egeo = "egeo.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/mverab/eGEOagents"
+Repository = "https://github.com/mverab/eGEOagents"
+Documentation = "https://github.com/mverab/eGEOagents#readme"
+
+[tool.setuptools]
+# The CLI package plus the root-level harness modules it reuses. Declaring the
+# py-modules keeps `import geo_eval` / `import llm_client` working in an editable
+# install; `python -m egeo` additionally bootstraps sys.path (see egeo/__init__.py).
+packages = ["egeo"]
+py-modules = ["geo_eval", "llm_client"]


### PR DESCRIPTION
## Summary

Makes E-GEO **runtime-agnostic**: the same GEO engine now runs outside Claude Code through a standalone `egeo` CLI and a pluggable runtime-adapter layer — **without duplicating any optimization logic**. Both the Claude Code agents and the CLI share one source of truth (`geo_eval.py` + `llm_client.py`).

## What's included

### Runtime adapter layer — `egeo/runtimes.py`
- `RuntimeAdapter` interface + a small registry (`get_runtime`, `list_runtimes`, `runtime_status`).
- `python` adapter (aliases `cli`, `local`) — in-process, honors `GEO_EVAL_MOCK`.
- `claude-code` adapter (alias `claude`) — host-executed descriptor, auto-detected via `.claude/`.

### Standalone `egeo` CLI — `egeo/cli.py` (`python -m egeo`)
| Command | Behavior |
|---|---|
| `optimize <file>` | Full pipeline (analyze → rank → rewrite → schema); writes `report.md`, `optimized/*.md`, `schema/*.json`, `analysis.json` |
| `evaluate` | Delegates to `geo_eval.py` — **byte-identical** output |
| `optimize-prompts` | Meta-optimizes the rewriter prompt (non-destructive by default) |
| `runtimes` | Lists runtime adapters and live status |

- `egeo/agents.py` + `egeo/pipeline.py` are thin wrappers that **reuse** `geo_eval._rank_candidates` / `_rewrite_description` and `llm_client.get_client()`.
- Entire CLI honors `GEO_EVAL_MOCK=1` for deterministic, offline runs (no API key).

### Packaging — `pyproject.toml`
- Installs the `egeo` package alongside the existing `geo_eval`/`llm_client` modules and registers the `egeo` console script (`pip install -e .`).

### CI / Release automation
- **`.github/workflows/release.yml`** — publishes a GitHub Release on `v*` tags (and manual `workflow_dispatch`), extracting the matching `CHANGELOG.md` section. Uses the GitHub-injected token (no PAT).
- **`.github/workflows/ci.yml`** — adds an `egeo` CLI smoke test under `GEO_EVAL_MOCK=1` (`runtimes` + `evaluate` + `optimize` + JSON-LD validation). Existing quality gates are unchanged.

### Docs & spec
- **README.md** — new "Standalone CLI (`egeo`)" and "Supported Runtimes" sections.
- **CHANGELOG.md** — `[Unreleased]` entry (Keep a Changelog format; section is what `release.yml` extracts for the GitHub Release).
- **OpenSpec change** `openspec/changes/add-runtime-adapters/` — proposal, tasks, design, and the new `runtime-adapters` capability spec.

## Validation
- All four CLI commands tested locally under `GEO_EVAL_MOCK=1`:
  - `egeo evaluate` output is byte-identical to `python geo_eval.py evaluate`.
  - `egeo optimize examples/sample-input.md` produces a full report + optimized content + valid JSON-LD (`validate_jsonld.py` → 0 errors).
  - `egeo optimize-prompts` is non-destructive (writes a `.candidate.txt`, leaves the working prompt untouched).
- `release.yml` / `ci.yml` validated as well-formed YAML; the `awk` CHANGELOG extraction was verified against the new `[Unreleased]` section.

> **Note:** Do **not** merge yet — opening for review per request.
