### PR TITLE
docs(changelog): mark 2.0.0 as released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [2.0.0] - 2026-06-30
+
 Runtime-agnostic execution: a standalone `egeo` CLI and a pluggable runtime
 adapter layer, so the same GEO engine runs outside Claude Code without
 duplicating any optimization logic.


### PR DESCRIPTION
## Summary

Housekeeping after the **v2.0.0** GitHub Release was published.

The v2.0 content (runtime adapter layer + standalone `egeo` CLI) was sitting under `## [Unreleased]`. This converts it to a dated `## [2.0.0] - 2026-06-30` entry and adds a fresh empty `## [Unreleased]` scaffold.

## Why

- Keeps `CHANGELOG.md` consistent with the now-published [v2.0.0 release](https://github.com/mverab/eGEOagents/releases/tag/v2.0.0).
- **Future-proofs the release automation:** `release.yml` extracts notes by matching `## [VERSION]`. With a dated `## [2.0.0]` section, any tag push resolves its notes by version. (The v2.0.0 tag did not auto-fire the workflow because it pointed to a local commit that predated `release.yml` on `main` — a one-time timing issue, not a workflow bug.)

## Notes

- Docs-only change. No code, no CI behavior change.
- `awk` extraction verified locally against the new `[2.0.0]` section (42 lines).