### PR TITLE
feat: add geo-loop mode — continuous GEO loops over a persistent workspace

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,6 +37,7 @@ Based on E-GEO research, these features consistently improve AI-engine rankings:
 | `/geo:batch <folder>` | Process all files in folder |
 | `/geo:report` | Generate comprehensive report |
 | `/geo:compete <query>` | Competitive analysis for query |
+| `/geo:loop [domain]` | One bounded loop-mode iteration over a workspace domain |
 
 ## Workflow
 
@@ -46,6 +47,28 @@ When user runs `/geo`:
 3. Delegate to **geo-rewriter** for content optimization
 4. Delegate to **geo-indexer** for schema markup generation
 5. Compile final report with before/after comparison
+
+## Loop Mode
+
+Loop mode is **opt-in** and additive. One-shot behavior (`/geo`, `/geo:audit`,
+`/geo:optimize`, `/geo:batch`, `/geo:report`, `/geo:compete`, the `geo-*` agents,
+`egeo optimize`, and the `geo-output/` convention) is unchanged and never
+requires a workspace.
+
+When the user runs `/geo:loop`:
+1. Follow `.claude/skills/geo-loop/SKILL.md` — it is the authoritative procedure.
+2. All state lives in `$EGEO_HOME` (default `~/.egeo/`). **Never write loop
+   state into the repo tree** — not `prompts/`, not `geo-output/`.
+3. `egeo loop run <domain> --dry-run` prints the plan (focus, collector deltas,
+   candidate signals) and writes nothing. Start there.
+4. Do **one** unit of work, then close the run: exactly one
+   `### YYYY-MM-DD run` Timeline entry ending in
+   `Outcome: success|partial|failure|no-op`, and exactly one `LOG.md` line.
+5. Artifacts follow `SUBSTRATE.md`: `signals/` for evidence (deduped via
+   `frequency`), `docs/` for durable knowledge, frontmatter on line 1, sources
+   cited. Verify with `python -m egeo.substrate_lint` before exiting.
+6. Ground truth comes from `$EGEO_HOME/data/*.jsonl` written by the collectors
+   (`egeo loop collect serp|page`). A simulated ranking is `confidence: low`.
 
 ## Output Standards
 

--- a/.claude/commands/geo-loop.md
+++ b/.claude/commands/geo-loop.md
@@ -1,0 +1,86 @@
+---
+name: geo:loop
+description: Run one bounded loop iteration over a workspace domain - read the charter and fresh collector data, do ONE unit of work, write substrate artifacts, close the run
+arguments:
+  - name: domain
+    description: Domain directory name under $EGEO_HOME/domains/ (defaults to the only domain when there is exactly one)
+    required: false
+---
+
+# /geo:loop Command
+
+Execute **one** eGEOagents loop iteration. Loop state lives in the workspace
+resolved from `$EGEO_HOME` (default `~/.egeo/`); the repo tree is never written
+to. One-shot `/geo <url>` is unaffected.
+
+Follow `.claude/skills/geo-loop/SKILL.md` — it is the authoritative procedure.
+
+## Workflow
+
+0. **Resolve the domain** - Use `$ARGUMENTS.domain`. If omitted and exactly one
+   directory exists under `$EGEO_HOME/domains/` (excluding `egeo-core`), use it;
+   otherwise list the domains and stop.
+1. **Plan** - `egeo loop run <domain> --dry-run`. Writes nothing. Non-zero exit
+   means stop and report (`egeo loop doctor` explains why).
+2. **Read state** - domain charter, `data/*.jsonl` deltas, existing
+   `signals/`, `docs/`, `config.yaml`.
+3. **One unit of work** - from `## Current focus`, else the first Backlog item.
+   Reuse `content-scoring`, `competitive-analysis`, `schema-generator`. No fresh
+   data and nothing actionable = `Outcome: no-op`.
+4. **Write artifacts** - `signals/<slug>.md` / `docs/<slug>.md` per
+   `SUBSTRATE.md`. Re-observed evidence increments `frequency` on the existing
+   signal instead of creating a file.
+5. **Close the run** - append exactly one `### YYYY-MM-DD run` Timeline entry
+   ending in `Outcome: success|partial|failure|no-op`, and exactly one `LOG.md`
+   line. Update `## Current focus` if it was completed.
+6. **Verify** - `python -m egeo.substrate_lint` and `egeo loop doctor`, then
+   re-read both appends. Violations are fixed before exiting.
+
+## Execution
+
+```
+Loop run: $ARGUMENTS.domain
+
+Step 1/6: Plan
+→ egeo loop run $ARGUMENTS.domain --dry-run
+
+Step 2/6: Reading workspace state
+→ $EGEO_HOME/domains/$ARGUMENTS.domain/README.md, data/, signals/, docs/
+
+Step 3/6: Unit of work
+→ <focus item>
+
+Step 4/6: Writing artifacts
+→ signals/... / docs/...
+
+Step 5/6: Closing the run
+→ Timeline entry + LOG.md line
+
+Step 6/6: Verification
+→ substrate_lint + doctor + re-read
+```
+
+## Output
+
+Written to `$EGEO_HOME/` (never `geo-output/`):
+- `signals/[slug].md` - evidence, deduped and frequency-counted
+- `docs/[slug].md` - durable knowledge, citing signals and sources
+- `domains/[domain]/README.md` - one appended Timeline entry
+- `LOG.md` - one appended line
+
+Then a three-line report: unit of work, artifacts written, outcome.
+
+## Example Usage
+
+```
+/geo:loop example-com
+/geo:loop                       (single-domain workspace)
+```
+
+Prerequisites, if the workspace is not set up yet:
+
+```bash
+egeo loop doctor                                  # bootstrap + health check
+egeo loop collect serp --query "best geo tool" --target-domain example.com
+egeo loop collect page --url https://example.com/pricing
+```

--- a/.claude/skills/geo-loop/SKILL.md
+++ b/.claude/skills/geo-loop/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: geo-loop
+description: Run one bounded eGEOagents loop iteration over a workspace domain - read the charter and fresh collector data, do ONE unit of work, write substrate artifacts, append one Timeline entry and one LOG line. Use for loop mode, /geo:loop, scheduled GEO runs, or continuous monitoring.
+---
+
+# GEO Loop Skill
+
+One wake-up = **one bounded unit of work**. This skill governs loop mode only;
+one-shot `/geo <url>` is unchanged and needs no workspace.
+
+## Non-negotiables
+
+1. **Never write to the eGEOagents repo tree.** Every write goes to the
+   workspace resolved from `$EGEO_HOME` (default `~/.egeo/`).
+2. **One unit of work per run.** Take the domain's `## Current focus`, or the
+   first Backlog item if focus is already satisfied. Do not batch.
+3. **Exactly one Timeline entry and exactly one LOG.md line per run.**
+4. **Write, then verify.** Re-read every file you wrote before exiting.
+5. **Never fabricate.** Rankings, competitors, and metrics come from collector
+   JSONL under `data/` or from a tool call in this session. A claim you cannot
+   cite is `confidence: low` with the uncertainty stated in the body.
+6. **Append-only history.** Never edit or delete an existing Timeline entry or
+   LOG line.
+
+## Procedure
+
+### 1. Resolve the plan
+
+```bash
+egeo loop run <domain> --dry-run
+```
+
+This is the source of truth for the run: it prints the charter's current focus,
+the backlog, collector records added since the last Timeline entry, and
+candidate signals. It writes nothing. Use `--json` when you want to parse it.
+
+If it exits non-zero, stop and report — the workspace or the domain charter is
+not in a runnable state (`egeo loop doctor` explains why).
+
+### 2. Read the state
+
+- `$EGEO_HOME/domains/<domain>/README.md` — charter, cadence, focus, backlog,
+  Timeline (the last entry tells you where the previous run stopped).
+- `$EGEO_HOME/data/<collector>/*.jsonl` — fresh ground truth.
+- `$EGEO_HOME/signals/` and `$EGEO_HOME/docs/` — what is already known, so you
+  dedupe instead of duplicating.
+- `$EGEO_HOME/config.yaml` — models, budgets, `reflect.auto_apply`.
+
+### 3. Do the work
+
+Pick the single unit of work and execute it with the existing GEO capability —
+the `content-scoring`, `competitive-analysis`, and `schema-generator` skills and
+the `geo-*` agents all apply unchanged. Typical units:
+
+| Situation in the plan | Unit of work |
+|---|---|
+| A target URL moved ≥3 positions | Write/update a signal explaining the move |
+| Target absent from top 10 repeatedly | Signal + a doc proposing the fix |
+| A tracked page's `content_hash` changed | Signal describing what changed |
+| A tracked page has no JSON-LD | Doc with copy-paste JSON-LD for that page |
+| No fresh data at all | Outcome `no-op` — do not invent work |
+
+Ranking positions from `data/serp/` are ground truth. Any *simulated* ranking
+you produce yourself is `confidence: low` and must say so in the body.
+
+### 4. Write artifacts (SUBSTRATE.md)
+
+`SUBSTRATE.md` in the repo root is the binding contract. In short:
+
+- `signals/<slug>.md` — evidence. `docs/<slug>.md` — durable knowledge.
+  Kebab-case filenames, English content, `kind` decides the folder.
+- Frontmatter on line 1: `kind`, `domains` (existing dirs under `domains/`),
+  `created`, `updated`, `confidence`, `sources`, plus `frequency` on signals.
+  `sources` may be empty only when `confidence: low`.
+- **Dedupe (§4):** re-observed evidence does **not** get a new file. On the
+  existing signal, increment `frequency`, set `updated` to today, and append one
+  dated Timeline entry.
+- Body above `## Timeline` = what is true now (rewrite freely).
+  `## Timeline` = append-only, newest at the bottom.
+- Docs cite signals and repo paths; signals cite collector JSONL lines
+  (`data/serp/example-com.jsonl#L42`).
+
+### 5. Close the run
+
+Append to `$EGEO_HOME/domains/<domain>/README.md`, at the very bottom:
+
+```markdown
+### 2026-07-24 run
+
+Checked serp deltas for example.com; pricing page dropped 3 → 7 for
+"best geo tool". Wrote signals/example-com-pricing-drop.md.
+
+Outcome: success
+```
+
+`Outcome:` is the last line and one of `success`, `partial`, `failure`, `no-op`.
+Then append exactly one line to `$EGEO_HOME/LOG.md`:
+
+```
+2026-07-24T18:20Z [example-com] run: wrote signals/example-com-pricing-drop.md, outcome=success
+```
+
+Grammar (SUBSTRATE.md §7): `<YYYY-MM-DDTHH:MMZ> [<domain>] <event>: <summary>`,
+UTC minute precision, appended at the bottom, summary ending in
+`outcome=<class>`.
+
+Keep `## Current focus` accurate: if the focus item is done, promote the next
+Backlog item and remove it from the Backlog.
+
+### 6. Verify, then exit
+
+```bash
+python -m egeo.substrate_lint            # defaults to $EGEO_HOME
+egeo loop doctor
+```
+
+Re-read the domain README and the tail of `LOG.md` to confirm your two
+appends landed exactly once. Fix violations before exiting; a run that leaves
+the substrate invalid is `Outcome: failure`.
+
+Report to the user in three lines: unit of work, artifacts written, outcome.
+
+## Collectors
+
+Collectors are deterministic and LLM-free; run them before a loop run when the
+plan shows no fresh data:
+
+```bash
+egeo loop collect serp --query "best geo tool" --target-domain example.com
+egeo loop collect page --url https://example.com/pricing
+```
+
+`serp` needs `BRAVE_API_KEY`; both honour the daily budgets in `config.yaml` and
+fail loudly rather than writing partial records. See `collectors/README.md` for
+the contract.
+
+## Common mistakes
+
+- Writing into the repo `prompts/`, `geo-output/`, or `signals/` instead of
+  `$EGEO_HOME` — loop state never lives in the repo.
+- Two Timeline entries (or two LOG lines) for one run.
+- A new signal file for evidence that already has one (use `frequency`).
+- Claiming a competitor ranking without a `data/serp/` line to cite.
+- Doing three units of work because the data looked interesting. One.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Loop mode** (opt-in): eGEOagents can now run as a continuous loop instead of
+  a one-shot pipeline. One-shot behavior is unchanged and never requires a
+  workspace.
+  - **Workspace** (`egeo/workspace.py`): all loop state resolves from
+    `$EGEO_HOME` (default `~/.egeo/`) — `LOG.md`, `config.yaml`, `signals/`,
+    `docs/`, `data/`, `domains/`, `prompts/`. Bootstrap is idempotent and never
+    overwrites an existing file. The repo tree is never written to by a loop run,
+    a collector pass, or a prompt optimization.
+  - **`SUBSTRATE.md`** vendored from `loopstack` — the artifact/layout contract —
+    plus `egeo/substrate_lint.py` to enforce the mechanically checkable parts
+    (frontmatter, domain charters, `LOG.md` grammar).
+  - **`egeo loop` command group** (`egeo/loop.py`): `doctor` (bootstrap +
+    health check), `collect <serp|page>` (collector pass), and `run <domain>`
+    (resolve and print the run plan; `--dry-run` writes nothing). LLM-free by
+    design — the interpretive work is performed by the agent.
+  - **Collectors** (`collectors/`): deterministic, budget-aware, append-only
+    JSONL senses — `serp` (Brave API, top-10 + target position) and `page`
+    (content hash, title, meta description, JSON-LD types, word count), both with
+    offline `--fixture` support and a documented 10-point contract.
+  - **`geo-loop` skill and `/geo:loop` command**: the run contract — one bounded
+    unit of work, exactly one Timeline entry ending in an `Outcome:` class, and
+    exactly one `LOG.md` line, verified before exit.
+  - **OpenSpec change** `add-geo-loop` with the `geo-loop-runtime` and
+    `loop-collectors` specs.
+
 ### Changed
+
+- `geo_eval.py` now resolves prompts workspace-first: a file in
+  `$EGEO_HOME/prompts/` overrides its repo `prompts/` counterpart, and
+  `optimize` writes its result there, so the repo `prompts/` stay pristine in
+  loop mode. With no workspace, behavior is identical to before.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Verify indexing pages:
 | `/geo:batch <folder>` | Process entire folder |
 | `/geo:report` | Generate executive report |
 | `/geo:compete <query>` | Competitive analysis |
+| `/geo:loop <domain>` | One bounded [loop-mode](#-loop-mode-continuous-geo) iteration over a workspace domain |
 
 ---
 
@@ -264,6 +265,7 @@ python -m egeo --help
 | `egeo evaluate` | Run the evaluation harness (reuses `geo_eval.py`, identical metrics) |
 | `egeo optimize-prompts` | Meta-optimize the rewriter prompt (non-destructive by default) |
 | `egeo runtimes` | List available runtime adapters and their status |
+| `egeo loop <run\|collect\|doctor>` | [Loop mode](#-loop-mode-continuous-geo) — plan a run, run a collector, or check the workspace |
 
 ```bash
 # Optimize a local content file (output dir defaults to ./geo-output)
@@ -301,6 +303,108 @@ Ranker, Rewriter, Indexer) can be driven by different execution hosts:
 > environment. Additional hosts (Cursor, Codex, Windsurf, …) can be added by
 > implementing the `RuntimeAdapter` interface in
 > [`egeo/runtimes.py`](egeo/runtimes.py).
+
+---
+
+## 🔁 Loop Mode (continuous GEO)
+
+One-shot GEO answers *"how is this page doing today?"*. **Loop mode** answers
+*"what changed, and what should I do about it?"* — week after week, without you
+asking. It is fully **opt-in**: `/geo <url>` and `egeo optimize` behave exactly
+as before and never need a workspace.
+
+### The workspace (`$EGEO_HOME`)
+
+All loop state lives **outside the repo**, in the workspace resolved from
+`$EGEO_HOME` (default `~/.egeo/`), so `git pull` never touches your data:
+
+```
+$EGEO_HOME/
+├── LOG.md                        # append-only activity feed (one line per event)
+├── config.yaml                   # cadence, models, budgets, scaling weights
+├── SUBSTRATE.md                  # the contract, vendored on bootstrap
+├── signals/<slug>.md             # evidence — deduped, frequency-counted
+├── docs/<slug>.md                # durable knowledge — analyses, decisions
+├── data/<collector>/*.jsonl      # raw collector output (not artifacts)
+├── domains/<loop>/README.md      # charter: focus, backlog, run Timeline
+└── prompts/                      # optimized prompts (repo prompts/ stay pristine)
+```
+
+The layout and the artifact rules are defined by [`SUBSTRATE.md`](SUBSTRATE.md)
+and mechanically enforced by `python -m egeo.substrate_lint`.
+
+### Commands
+
+| Command | What it does |
+|---------|--------------|
+| `egeo loop doctor` | Bootstrap the workspace if missing, then health-check it (layout, config, budgets, substrate lint) |
+| `egeo loop collect serp` | Record a search-result snapshot (Brave API) into `data/serp/*.jsonl` |
+| `egeo loop collect page` | Record a page snapshot (hash, title, meta, JSON-LD types, word count) into `data/page/*.jsonl` |
+| `egeo loop run <domain>` | Resolve and print the run plan — current focus, fresh collector deltas, candidate signals |
+| `/geo:loop <domain>` | Execute one bounded loop iteration in Claude Code (the agent does the interpretive work) |
+
+```bash
+# 1. Create the workspace
+egeo loop doctor
+
+# 2. Describe what you want watched: $EGEO_HOME/domains/example-com/README.md
+#    (## Charter, ## Cadence, ## Current focus, ## Backlog, ## Timeline)
+
+# 3. Collect ground truth
+export BRAVE_API_KEY=...
+egeo loop collect serp --query "best geo tool" --target-domain example.com
+egeo loop collect page --url https://example.com/pricing
+
+# 4. See what a run would do — writes nothing
+egeo loop run example-com --dry-run
+
+# 5. Do the run (Claude Code, or headless)
+claude -p "/geo:loop example-com"
+```
+
+`egeo loop run` is **LLM-free by design**: it is the trigger seam that prepares
+and validates the plan. The reasoning happens in
+[`.claude/skills/geo-loop/SKILL.md`](.claude/skills/geo-loop/SKILL.md), which
+enforces the run contract: **one** unit of work, **one** Timeline entry ending in
+`Outcome: success|partial|failure|no-op`, **one** `LOG.md` line, verified before
+exit.
+
+### Collectors
+
+Collectors are the loop's senses: deterministic, LLM-free, budget-aware, and
+append-only. Every collector honours the same 10-point contract
+([`collectors/README.md`](collectors/README.md)) — in short: write JSONL to
+`$EGEO_HOME/data/<name>/`, one record per observation with a `schema_version`,
+respect the daily budget in `config.yaml`, append exactly one `LOG.md` line per
+pass, and **fail loudly** instead of writing a partial or fabricated record.
+
+| Collector | Needs | Output |
+|-----------|-------|--------|
+| `serp` | `BRAVE_API_KEY` | Top-10 results per query + your target's position |
+| `page` | nothing | `content_hash`, title, meta description, JSON-LD types, word count |
+
+Both accept `--fixture` for offline, deterministic runs — that is how they are
+tested without touching the network.
+
+### Scheduling (Hermes cron reference)
+
+Any scheduler drives the same commands. Pin **provider and model per job**, and
+for anything more frequent than weekly deliver **locally** and let a weekly
+digest do the notifying:
+
+```
+# hourly — local delivery only (JSONL + LOG line, no notification)
+0 * * * *   provider=anthropic model=claude-sonnet-4-5 deliver=local \
+            egeo loop collect page --url https://example.com/pricing
+
+# daily — one bounded loop run
+30 6 * * *  provider=anthropic model=claude-sonnet-4-5 deliver=local \
+            claude -p "/geo:loop example-com"
+
+# weekly — the only job that pings you
+0 9 * * 1   provider=anthropic model=claude-opus-4-1 deliver=notify \
+            claude -p "Summarize $EGEO_HOME/LOG.md for the past 7 days"
+```
 
 ---
 
@@ -390,14 +494,30 @@ E-GEO uses **4 specialized AI agents** orchestrated by Claude Code:
 ├── skills/
 │   ├── competitive-analysis/    # Auto-triggered competitor analysis
 │   ├── content-scoring/         # Auto-triggered scoring
-│   └── schema-generator/        # Auto-triggered schema
+│   ├── schema-generator/        # Auto-triggered schema
+│   └── geo-loop/                # Loop-mode run contract
 └── commands/
     ├── geo.md                   # Main command
     ├── geo-audit.md
     ├── geo-optimize.md
     ├── geo-batch.md
     ├── geo-report.md
-    └── geo-compete.md
+    ├── geo-compete.md
+    └── geo-loop.md
+
+egeo/                            # Standalone CLI package
+├── cli.py                       # `egeo` entrypoint
+├── loop.py                      # `egeo loop run|collect|doctor`
+├── workspace.py                 # $EGEO_HOME resolution + bootstrap
+└── substrate_lint.py            # SUBSTRATE.md enforcement
+
+collectors/                      # Deterministic, LLM-free senses
+├── README.md                    # The collector contract
+├── serp.py                      # Brave search snapshots
+├── page.py                      # Page snapshots
+└── fixtures/                    # Offline test data
+
+SUBSTRATE.md                     # Workspace/artifact contract
 ```
 
 ---

--- a/SUBSTRATE.md
+++ b/SUBSTRATE.md
@@ -1,0 +1,171 @@
+<!--
+Vendored from mverab/loopstack SUBSTRATE.md (loop-engineering system repo).
+Upstream commit: 9696dd5
+Vendored: 2026-07-24. Contents are verbatim; this repo consumes the contract
+as-is and copies this file into $EGEO_HOME at bootstrap (see egeo/workspace.py).
+Update by re-copying from loopstack, never by editing here.
+-->
+
+# Substrate Contract
+
+**Status:** Normative. This file is the single source of truth for the
+knowledge-base contract. `ARCHITECTURE.md` §2 explains *why* the model looks
+like this; this file defines *what* is valid. Where the two disagree, this
+file wins and `ARCHITECTURE.md` is the bug.
+
+**Audience:** every loop (human or agent) that reads or writes substrate, and
+`scripts/substrate_lint.py`, which enforces the rules below mechanically.
+
+**Vendoring:** products adopt the substrate by copying this one file into their
+workspace at bootstrap. It has no dependencies on the rest of this repo.
+
+---
+
+## 1. Layout
+
+```
+<substrate root>/
+├── LOG.md                  # global append-only activity feed (one line per event)
+├── signals/<slug>.md       # kind: signal — evidence, deduped, frequency-counted
+├── docs/<slug>.md          # kind: doc — durable knowledge: analyses, decisions
+├── data/<collector>/*.jsonl  # collector output — NOT artifacts, no frontmatter
+└── domains/<loop-name>/README.md  # charter, cadence, focus, backlog, ## Timeline
+```
+
+Runtime config (`config.yaml`) and, from Phase 4, `proposals/` sit alongside
+this layout; they are loop machinery, not artifacts, and are out of scope here.
+
+- Artifacts are foldered by **kind**. `domains` is a frontmatter **field**
+  (a list), never a folder for artifacts.
+- File and directory names are kebab-case.
+- All content is English.
+- In `loopstack` (this repo) the substrate root is the repo root — this repo is
+  a single-owner meta-repo whose state IS its content (`DECISIONS.md` D3).
+  Every other product keeps its substrate in a per-user workspace outside the
+  repo (`$<PRODUCT>_HOME`).
+
+## 2. Artifact frontmatter
+
+Every artifact is a markdown file that begins on line 1 with a YAML
+frontmatter block delimited by `---`:
+
+```yaml
+---
+kind: signal
+domains: [loopstack-core]
+created: 2026-07-24
+updated: 2026-07-24
+frequency: 1
+confidence: high
+sources: [ARCHITECTURE.md#2, data/serp/slashstack.jsonl#L120]
+---
+```
+
+| Field | Required | Type | Rule |
+|---|---|---|---|
+| `kind` | yes | enum | `signal` or `doc`. No other value is valid today (see §6). |
+| `domains` | yes | list | Non-empty. Each entry must be an existing directory under `domains/`. |
+| `created` | yes | date | `YYYY-MM-DD`. |
+| `updated` | yes | date | `YYYY-MM-DD`, never earlier than `created`. |
+| `confidence` | yes | enum | `high`, `medium`, or `low`. |
+| `sources` | yes | list | May be empty **only** when `confidence: low`. |
+| `frequency` | signals only | integer | `>= 1`. Dedupe counter. Not valid on `doc`. |
+
+The frontmatter subset used here is deliberately small so it can be parsed
+without a YAML library: scalars, `YYYY-MM-DD` dates, and single-line inline
+lists (`[a, b]`, or `[]` for empty).
+
+## 3. Body shape
+
+- **Body = what is true now.** Everything above `## Timeline` may be rewritten
+  freely as understanding improves. There is no history to preserve there.
+- **`## Timeline` = what happened.** Append-only, dated entries, newest at the
+  bottom. Existing entries are never edited or deleted. A diff that modifies
+  or removes an existing Timeline entry is rejected in review.
+- **`sources` makes claims auditable.** Docs cite signals and repo paths;
+  signals cite collector JSONL lines or vendor source locations. An artifact
+  with no sources is `confidence: low`.
+
+## 4. Signal dedupe
+
+Re-observing evidence that matches an existing signal does **not** create a
+second file. Instead, on the existing signal:
+
+1. increment `frequency` by one,
+2. set `updated` to today,
+3. append one dated entry to its `## Timeline`.
+
+A new signal file is created only for genuinely new evidence.
+
+## 5. Domain README (the loop charter)
+
+Each directory under `domains/` contains a `README.md` with these level-2
+sections, in this order:
+
+1. `## Charter` — mission, scope, what this loop optimizes for.
+2. `## Cadence` — trigger schedule.
+3. `## Current focus` — exactly one item.
+4. `## Backlog` — ordered list.
+5. `## Timeline` — append-only run log, last section in the file.
+
+Every loop run appends one `### <YYYY-MM-DD> run` entry to the Timeline, and
+that entry ends with an `Outcome:` line classed as `success`, `partial`,
+`failure`, or `no-op`. Those Outcome lines are the raw material of the reflect
+loop, so the classes are a closed set.
+
+A domain README is a charter, not an artifact: it has no frontmatter.
+
+## 6. Earning a new kind
+
+`signal` and `doc` are the only kinds today. A new kind is added only through
+an approved change proposal that shows it clears all three bars:
+
+- **(a) own status machine** — states and legal transitions the existing kinds
+  do not have;
+- **(b) queryable fields** — frontmatter fields loops actually filter on;
+- **(c) distinct body shape** — a body that cannot be expressed as evidence or
+  as durable knowledge.
+
+`learning` and `skill-proposal` clear the bar when the reflect loop ships
+(Phase 4). `task` does not clear it: work items live in the domain Backlog and
+run outcomes live in the domain Timeline.
+
+## 7. LOG.md
+
+`LOG.md` is the global append-only activity feed: the human's 30-second "what
+have my loops been doing" view and the digest source for delivery. New lines
+are appended at the **bottom** (oldest first) so concurrent writers merge
+cleanly.
+
+Grammar — one event per line, exactly:
+
+```
+<ISO-8601 UTC timestamp> [<domain>] <event>: <summary>
+```
+
+- timestamp: `YYYY-MM-DDTHH:MMZ` (minute precision, always UTC)
+- `<domain>`: a directory name under `domains/`, in square brackets
+- `<event>`: a single kebab-case token (`run`, `collect`, `bootstrap`,
+  `review`, ...) followed by `: `
+- `<summary>`: free text, one line, ending in `outcome=<success|partial|failure|no-op>`
+  for events that represent a completed unit of work
+
+Example:
+
+```
+2026-07-24T18:20Z [loopstack-core] bootstrap: created substrate skeleton, outcome=success
+```
+
+Blank lines, markdown headings (`#`), and HTML comment blocks (`<!-- ... -->`,
+including multi-line ones) are ignored by the parser — that is where the file's
+own header lives. Every other line must match the grammar.
+
+Every collector pass, loop run, and proposal decision appends exactly one line.
+
+## 8. Enforcement
+
+`scripts/substrate_lint.py` (Python stdlib only) checks everything in §2, §5,
+§6, and §7 that is mechanically checkable, and exits non-zero with one
+`path:line: message` per violation. CI runs it, plus
+`openspec validate --strict`, on every push and pull request. Timeline
+append-only (§3) is enforced by review at this stage.

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,6 +4,9 @@
 - `geo_eval.py`: evaluation + lightweight prompt meta-optimization
 - `llm_client.py`: OpenAI-compatible HTTP client (stdlib only)
 - `prompts/`: prompt templates
+- `egeo/loop.py`: loop-mode CLI (`egeo loop run|collect|doctor`)
+- `egeo/workspace.py`: `$EGEO_HOME` resolution + substrate bootstrap
+- `collectors/`: deterministic collectors (`serp`, `page`) and their fixtures
 
 ## Environment
 - `OPENAI_API_KEY`: required
@@ -35,4 +38,70 @@ python3 geo_eval.py evaluate --dataset /absolute/path/to/dataset.jsonl
 python3 geo_eval.py optimize --train /absolute/path/to/train.jsonl --val /absolute/path/to/val.jsonl --iters 5
 ```
 
-This overwrites `prompts/rewriter_user.txt` with the best-on-validation prompt.
+The best-on-validation prompt is written to
+`prompts/rewriter_user.candidate.txt`; pass `--apply` to promote it over the
+working `prompts/rewriter_user.txt`. When a loop workspace exists (see below)
+both destinations move to `$EGEO_HOME/prompts/` and the repo `prompts/`
+directory is left untouched.
+
+## Loop mode
+
+Loop mode is opt-in and keeps all state in the workspace resolved from
+`$EGEO_HOME` (default `~/.egeo/`). The repo tree is never written to by a loop
+run, a collector pass, or a prompt optimization. Everything above keeps working
+without a workspace.
+
+### Environment
+- `EGEO_HOME`: optional (defaults to `~/.egeo`)
+- `BRAVE_API_KEY`: required by the `serp` collector only
+
+### Commands
+
+```bash
+# Bootstrap (idempotent) + health check: layout, config, budgets, substrate lint
+egeo loop doctor
+
+# Collector passes — deterministic, budget-aware, append-only JSONL
+egeo loop collect serp --query "best geo tool" --target-domain example.com
+egeo loop collect page --url https://example.com/pricing
+
+# Offline/deterministic collector runs (no network)
+egeo loop collect serp --query "best geo tool" --target-domain example.com \
+  --fixture collectors/fixtures/serp_brave_response.json
+egeo loop collect page --url https://example.com/pricing \
+  --fixture collectors/fixtures/pages
+
+# Print the run plan for a domain — writes nothing
+egeo loop run example-com --dry-run
+
+# Execute one bounded iteration (the agent does the interpretive work)
+claude -p "/geo:loop example-com"
+
+# Verify the workspace against SUBSTRATE.md
+python3 -m egeo.substrate_lint
+```
+
+### The run contract
+
+One wake-up performs at most **one** unit of work from the domain's
+`## Current focus` or `## Backlog`, appends exactly **one**
+`### YYYY-MM-DD run` Timeline entry ending in
+`Outcome: success|partial|failure|no-op`, appends exactly **one** `LOG.md` line,
+and verifies both writes before exiting. See
+[`.claude/skills/geo-loop/SKILL.md`](.claude/skills/geo-loop/SKILL.md) and
+[`SUBSTRATE.md`](SUBSTRATE.md).
+
+### Scheduling
+
+Any scheduler works; pin provider and model per job. Jobs more frequent than
+weekly deliver locally (JSONL + LOG line) and a weekly digest job summarizes
+`$EGEO_HOME/LOG.md` — that digest is the only job that notifies.
+
+```
+0 * * * *   provider=anthropic model=claude-sonnet-4-5 deliver=local \
+            egeo loop collect page --url https://example.com/pricing
+30 6 * * *  provider=anthropic model=claude-sonnet-4-5 deliver=local \
+            claude -p "/geo:loop example-com"
+0 9 * * 1   provider=anthropic model=claude-opus-4-1 deliver=notify \
+            claude -p "Summarize $EGEO_HOME/LOG.md for the past 7 days"
+```

--- a/collectors/README.md
+++ b/collectors/README.md
@@ -1,0 +1,112 @@
+# Collectors — the data layer of loop mode
+
+**Collectors write data. Agents write knowledge.** A collector observes the
+world and records what it saw, verbatim and without opinion. Turning those
+observations into signals and docs is the agent's job (`.claude/skills/geo-loop/`).
+Keeping the two apart is what makes loop mode cheap, deterministic, and auditable.
+
+## The contract
+
+A collector in this directory MUST:
+
+1. **Be deterministic and LLM-free.** No model calls, no prompts, no
+   interpretation. Given the same input it produces the same record.
+2. **Read configuration from the workspace, credentials from the environment.**
+   Inputs come from `$EGEO_HOME/config.yaml` (`collectors.<name>.*`); secrets
+   come from env vars (`BRAVE_API_KEY`). Nothing is read from the repo tree and
+   secret values are never printed or logged.
+3. **Append versioned JSONL.** One JSON object per observation, appended to
+   `$EGEO_HOME/data/<collector>/<stream>.jsonl`. Every record carries:
+   - `v` — integer schema version,
+   - `ts` — ISO-8601 UTC timestamp,
+   - a natural key (`query`, `url`, …) sufficient for read-side dedupe.
+4. **Never rewrite history.** Append only. Existing lines are never modified,
+   reordered, or deleted; the agent dedupes on read.
+5. **Be idempotent to re-run.** Running twice is safe: it produces two
+   observations with distinct `ts`, never a corrupted stream.
+6. **Never write interpretive artifacts.** A collector must not touch
+   `signals/`, `docs/`, or any domain `README.md` body.
+7. **Log exactly one line per pass.** On success, append one `LOG.md` line
+   ending in `outcome=<success|partial|failure|no-op>`.
+8. **Fail loudly.** Exit non-zero on hard failure (auth, network, schema,
+   budget) and write no record for the failed observation. A collector that
+   quietly stops collecting is worse than one that crashes.
+9. **Support fixture mode.** `--fixture <path>` replays recorded responses from
+   disk so the contract is testable with no network and no API key.
+10. **Expose `main(argv)`.** So `egeo loop collect <name>` can invoke the
+    collector in-process, with the same behavior as running the file directly.
+
+## Shipped collectors
+
+| Collector | Stream | Record |
+|---|---|---|
+| `serp.py` | `data/serp/<query-slug>.jsonl` | `{v, ts, query, engine, results[≤10], target_domain, target_position}` |
+| `page.py` | `data/page/<page-slug>.jsonl` | `{v, ts, url, status, content_hash, title, meta_description, jsonld_types, word_count}` |
+
+### `serp.py` — position history from the Brave Search API
+
+```bash
+export BRAVE_API_KEY=...                  # never printed, never written to disk
+python collectors/serp.py                 # all queries from config.yaml
+python collectors/serp.py --query "best geo tool"
+python collectors/serp.py --fixture collectors/fixtures/serp_brave_response.json
+python -m egeo loop collect serp          # equivalent, in-process
+```
+
+Brave is called over its **HTTP API directly**, not through the Brave MCP:
+collectors run under cron with no agent attached, so an MCP server is not
+available to them. The MCP stays the path for interactive agent sessions. Live
+passes are paced at ≤1 query/second and refuse to exceed
+`budgets.queries_per_day`.
+
+Config:
+
+```yaml
+collectors:
+  serp:
+    target_domain: example.com     # position is reported for this domain
+    queries:
+      - best geo optimization tool
+      - how to rank in chatgpt
+```
+
+### `page.py` — content and schema drift on your own pages
+
+```bash
+python collectors/page.py
+python collectors/page.py --url https://example.com/pricing
+python collectors/page.py --fixture collectors/fixtures/pages/
+python -m egeo loop collect page
+```
+
+`content_hash` is a SHA-256 of the fetched body, so an unchanged page produces
+an unchanged hash across passes — that is how the agent detects drift. HTML is
+parsed with the standard library only (`html.parser`); there is no `requests` or
+`beautifulsoup4` dependency anywhere in loop mode.
+
+Config:
+
+```yaml
+collectors:
+  page:
+    urls:
+      - https://example.com/
+      - https://example.com/pricing
+```
+
+## Fixtures
+
+`fixtures/serp_brave_response.json` is a recorded Brave `/res/v1/web/search`
+response body; `fixtures/pages/*.html` are recorded page bodies whose file names
+encode the URL slug. Fixture mode is what CI runs: no network, no key, same code
+path, same schema.
+
+## Adding a collector
+
+1. Copy the shape of `page.py` (argparse, `main(argv)`, `--fixture`, stdlib only).
+2. Write records through `egeo.workspace` helpers so `$EGEO_HOME` is resolved in
+   exactly one place.
+3. Add a fixture and a `--fixture` path that never touches the network.
+4. Register it in `egeo/loop.py`'s collector table and document it above.
+5. Re-read this contract before opening the PR — points 1, 3, 6, and 8 are the
+   ones reviewers reject changes over.

--- a/collectors/_common.py
+++ b/collectors/_common.py
@@ -1,0 +1,110 @@
+"""Shared plumbing for collectors: paths, slugs, JSONL appends, HTTP, LOG lines.
+
+Standard library only, in the style of ``llm_client.py``. Everything that writes
+goes through :mod:`egeo.workspace`, so ``$EGEO_HOME`` is resolved in exactly one
+place. See ``collectors/README.md`` for the contract these helpers exist to make
+easy to honor.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+# Allow ``python collectors/serp.py`` from anywhere: the repo root ships the
+# ``egeo`` package this module depends on.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from egeo import workspace  # noqa: E402  (after the sys.path bootstrap above)
+
+USER_AGENT = "egeo-collector/2.0 (+https://github.com/mverab/eGEOagents)"
+
+
+class CollectorError(RuntimeError):
+    """Hard failure: the pass must exit non-zero and write no partial record."""
+
+
+def slugify(value: str, max_length: int = 60) -> str:
+    """Kebab-case, filesystem-safe stream name for a query or URL."""
+    value = re.sub(r"^https?://", "", value.strip().lower())
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return (value[:max_length].rstrip("-") or "untitled")
+
+
+def stream_path(collector: str, stream: str, home: Optional[Path] = None) -> Path:
+    """Path of ``data/<collector>/<stream>.jsonl``, creating the directory."""
+    directory = workspace.data_dir(collector, home)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{stream}.jsonl"
+
+
+def append_record(path: Path, record: Dict[str, Any]) -> None:
+    """Append exactly one JSON object as one line. Never rewrites the file."""
+    line = json.dumps(record, ensure_ascii=False, sort_keys=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def read_records(path: Path) -> List[Dict[str, Any]]:
+    """Read a JSONL stream, skipping blank lines. Missing file → empty list."""
+    if not path.is_file():
+        return []
+    records: List[Dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            records.append(json.loads(line))
+    return records
+
+
+def count_today(paths: Iterable[Path], today: str) -> int:
+    """How many records in these streams carry a ``ts`` on ``today`` (UTC date)."""
+    total = 0
+    for path in paths:
+        for record in read_records(path):
+            if str(record.get("ts", "")).startswith(today):
+                total += 1
+    return total
+
+
+def log_pass(collector: str, summary: str, home: Optional[Path] = None) -> str:
+    """Append the collector's single LOG.md line for this pass."""
+    return workspace.append_log(workspace.MACHINERY_DOMAIN, f"collect-{collector}", summary, home=home)
+
+
+def http_get(url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 30):
+    """GET a URL with stdlib urllib. Returns ``(status, body_text)``.
+
+    Raises :class:`CollectorError` on transport failure. HTTP error responses are
+    returned with their status so the caller decides whether they are fatal.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, **(headers or {})})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            return response.status, response.read().decode(charset, errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        return exc.code, body
+    except urllib.error.URLError as exc:
+        raise CollectorError(f"network failure for {url}: {exc.reason}") from exc
+    except OSError as exc:  # timeouts, DNS, TLS
+        raise CollectorError(f"network failure for {url}: {exc}") from exc
+
+
+def ensure_workspace(home: Optional[Path] = None) -> Path:
+    """Resolve and bootstrap the workspace, returning its path."""
+    resolved = home or workspace.resolve_home()
+    workspace.bootstrap(resolved)
+    return resolved
+
+
+def fail(message: str) -> int:
+    """Print an actionable error to stderr and return the exit status."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1

--- a/collectors/fixtures/README.md
+++ b/collectors/fixtures/README.md
@@ -1,0 +1,13 @@
+# Collector fixtures
+
+Recorded responses so collector contract tests run with no network and no API
+key. Content is synthetic; the *shape* mirrors the real responses.
+
+| Fixture | Replayed by |
+|---|---|
+| `serp_brave_response.json` | `python collectors/serp.py --fixture collectors/fixtures/serp_brave_response.json` |
+| `pages/<page-slug>.html` | `python collectors/page.py --fixture collectors/fixtures/pages/` |
+
+Page fixtures are matched by slug: `https://example.com/pricing` resolves to
+`pages/example-com-pricing.html` (see `_common.slugify`). To record a new one,
+save the real response body under the slug name and never commit private data.

--- a/collectors/fixtures/pages/example-com-pricing.html
+++ b/collectors/fixtures/pages/example-com-pricing.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Pricing — Example GEO</title>
+  <meta name="description" content="Simple pricing for the best GEO toolkit: free, pro, and enterprise tiers.">
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Product","name":"Example GEO Pro","offers":{"@type":"Offer","price":"49.00","priceCurrency":"USD"}}
+  </script>
+  <style>body { margin: 0 }</style>
+</head>
+<body>
+  <h1>Pricing</h1>
+  <p>Example GEO is the fastest way to optimize content for AI search engines.
+  Start free, upgrade when your pages start ranking in generative answers.</p>
+  <ul><li>Free: one page per month</li><li>Pro: unlimited pages and SERP history</li><li>Enterprise: audit trail and SSO</li></ul>
+  <script>console.log("this text must not be counted as content");</script>
+</body>
+</html>

--- a/collectors/fixtures/pages/example-com.html
+++ b/collectors/fixtures/pages/example-com.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Example GEO — optimize content for AI search engines</title>
+  <meta property="og:description" content="Open-source generative engine optimization: audit, rewrite, and track.">
+</head>
+<body>
+  <h1>Rank in AI answers</h1>
+  <p>Example GEO audits a page, rewrites it against the ten GEO features, and emits JSON-LD.</p>
+</body>
+</html>

--- a/collectors/fixtures/serp_brave_response.json
+++ b/collectors/fixtures/serp_brave_response.json
@@ -1,0 +1,20 @@
+{
+  "_fixture": "Recorded shape of a Brave Search API /res/v1/web/search response body, trimmed to the fields collectors/serp.py reads. Synthetic content, real schema: used by offline contract tests (python collectors/serp.py --fixture ...).",
+  "query": {"original": "best geo optimization tool"},
+  "web": {
+    "type": "search",
+    "results": [
+      {"title": "The 12 Best GEO Tools (2026 Review)", "url": "https://searchmonitor.example/blog/best-geo-tools", "description": "Ranked roundup of generative engine optimization tools."},
+      {"title": "GEO Optimization Platform", "url": "https://www.rivalgeo.example/platform", "description": "Enterprise GEO suite."},
+      {"title": "E-GEO: open-source generative engine optimization", "url": "https://example.com/egeo", "description": "Zero-effort GEO for AI search engines."},
+      {"title": "How AI search engines pick sources", "url": "https://airesearch.example/papers/geo", "description": "Study of citation behavior."},
+      {"title": "GEO vs SEO explained", "url": "https://contentlab.example/geo-vs-seo", "description": "Primer on the differences."},
+      {"title": "Best AI visibility trackers", "url": "https://toolsdigest.example/ai-visibility", "description": "Comparison table."},
+      {"title": "Optimizing content for ChatGPT answers", "url": "https://promptcraft.example/chatgpt-visibility", "description": "Tactics and pitfalls."},
+      {"title": "Schema markup for AI answers", "url": "https://schemaguide.example/ai", "description": "JSON-LD patterns."},
+      {"title": "Perplexity ranking factors", "url": "https://serpnotes.example/perplexity", "description": "Observed factors."},
+      {"title": "GEO checklist", "url": "https://growthwiki.example/geo-checklist", "description": "Implementation checklist."},
+      {"title": "Overflow result (must be dropped at 10)", "url": "https://ignored.example/eleventh", "description": "Beyond top-10."}
+    ]
+  }
+}

--- a/collectors/page.py
+++ b/collectors/page.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Page collector: content and schema drift on the pages you optimize.
+
+Deterministic, zero LLM calls. One record per URL per pass, appended to
+``$EGEO_HOME/data/page/<page-slug>.jsonl``::
+
+    {"v": 1, "ts": "...Z", "url": "...", "status": 200,
+     "content_hash": "<sha256 of the body>", "title": "...",
+     "meta_description": "..." | null, "jsonld_types": ["Article"], "word_count": 812}
+
+``content_hash`` is stable for an unchanged page, so the agent detects drift by
+comparing consecutive records. HTML is parsed with ``html.parser`` — no
+third-party dependency anywhere in loop mode.
+
+Usage::
+
+    python collectors/page.py                      # urls from config.yaml
+    python collectors/page.py --url https://example.com/pricing
+    python collectors/page.py --fixture collectors/fixtures/pages/
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+if __package__ in (None, ""):  # executed as a script
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _common as common  # noqa: E402
+from egeo import workspace  # noqa: E402
+
+SCHEMA_VERSION = 1
+COLLECTOR = "page"
+FIXTURE_SUFFIXES = (".html", ".htm", ".txt")
+
+
+class _PageParser(HTMLParser):
+    """Extract title, meta description, JSON-LD @types and visible text."""
+
+    _SKIP_TEXT_IN = {"script", "style", "noscript", "template"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title: Optional[str] = None
+        self.meta_description: Optional[str] = None
+        self.jsonld_blocks: List[str] = []
+        self.text_parts: List[str] = []
+        self._stack: List[str] = []
+        self._in_title = False
+        self._in_jsonld = False
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        self._stack.append(tag)
+        attributes = {key.lower(): (value or "") for key, value in attrs}
+        if tag == "title" and self.title is None:
+            self._in_title = True
+        elif tag == "meta":
+            name = attributes.get("name", "").lower()
+            prop = attributes.get("property", "").lower()
+            if self.meta_description is None and name == "description":
+                self.meta_description = attributes.get("content", "").strip() or None
+            elif self.meta_description is None and prop == "og:description":
+                self.meta_description = attributes.get("content", "").strip() or None
+        elif tag == "script" and attributes.get("type", "").lower() == "application/ld+json":
+            self._in_jsonld = True
+            self.jsonld_blocks.append("")
+
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag == "title":
+            self._in_title = False
+        if tag == "script":
+            self._in_jsonld = False
+        for index in range(len(self._stack) - 1, -1, -1):
+            if self._stack[index] == tag:
+                del self._stack[index:]
+                break
+
+    def handle_data(self, data):
+        if self._in_title:
+            self.title = ((self.title or "") + data).strip() or None
+            return
+        if self._in_jsonld and self.jsonld_blocks:
+            self.jsonld_blocks[-1] += data
+            return
+        if not any(tag in self._SKIP_TEXT_IN for tag in self._stack):
+            self.text_parts.append(data)
+
+
+def _jsonld_types(blocks: List[str]) -> List[str]:
+    """Collect declared ``@type`` values across all JSON-LD blocks, in order.
+
+    Unparseable blocks are recorded as ``"<invalid-json-ld>"``: the collector
+    reports what is on the page, it does not judge it.
+    """
+    types: List[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            value = node.get("@type")
+            if isinstance(value, str):
+                types.append(value)
+            elif isinstance(value, list):
+                types.extend(str(item) for item in value)
+            for child in node.values():
+                walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+
+    for block in blocks:
+        text = block.strip()
+        if not text:
+            continue
+        try:
+            walk(json.loads(text))
+        except json.JSONDecodeError:
+            types.append("<invalid-json-ld>")
+
+    seen: List[str] = []
+    for value in types:
+        if value not in seen:
+            seen.append(value)
+    return seen
+
+
+def parse_page(url: str, status: int, body: str) -> Dict[str, Any]:
+    """Turn a fetched page body into one versioned observation record."""
+    parser = _PageParser()
+    parser.feed(body)
+    parser.close()
+    text = re.sub(r"\s+", " ", " ".join(parser.text_parts)).strip()
+    return {
+        "v": SCHEMA_VERSION,
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "url": url,
+        "status": status,
+        "content_hash": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "title": parser.title,
+        "meta_description": parser.meta_description,
+        "jsonld_types": _jsonld_types(parser.jsonld_blocks),
+        "word_count": len(text.split()) if text else 0,
+    }
+
+
+def fixture_body(fixture: Path, url: str) -> str:
+    """Read the recorded body for ``url`` from a fixture file or directory.
+
+    A directory is matched by slug: ``<page-slug>.html`` (``.htm``/``.txt`` also
+    accepted). A file is used directly, which makes single-URL replays trivial.
+    """
+    if fixture.is_file():
+        return fixture.read_text(encoding="utf-8")
+    if not fixture.is_dir():
+        raise common.CollectorError(f"fixture not found: {fixture}")
+    slug = common.slugify(url)
+    for suffix in FIXTURE_SUFFIXES:
+        candidate = fixture / f"{slug}{suffix}"
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    raise common.CollectorError(
+        f"no fixture for {url} in {fixture} (expected {slug}{FIXTURE_SUFFIXES[0]})"
+    )
+
+
+def collect(
+    *,
+    urls: List[str],
+    home: Path,
+    fixture: Optional[Path] = None,
+    budget: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run one pass over ``urls``. Returns a machine-readable summary."""
+    if not urls:
+        raise common.CollectorError(
+            "no URLs configured: add collectors.page.urls to "
+            f"{home / workspace.CONFIG_NAME} or pass --url"
+        )
+    if budget:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        already = common.count_today(sorted(workspace.data_dir(COLLECTOR, home).glob("*.jsonl")), today)
+        if already + len(urls) > budget:
+            raise common.CollectorError(
+                f"budgets.pages_per_day={budget} would be exceeded: "
+                f"{already} recorded today + {len(urls)} requested. "
+                "Raise the budget in config.yaml or shorten the URL list."
+            )
+
+    written: List[Dict[str, Any]] = []
+    changed = 0
+    for url in urls:
+        if fixture is not None:
+            status, body = 200, fixture_body(fixture, url)
+        else:
+            status, body = common.http_get(url)
+            if status >= 400:
+                raise common.CollectorError(f"{url} returned HTTP {status}")
+        record = parse_page(url, status, body)
+        path = common.stream_path(COLLECTOR, common.slugify(url), home)
+        previous = common.read_records(path)
+        if previous and previous[-1].get("content_hash") != record["content_hash"]:
+            changed += 1
+        common.append_record(path, record)
+        written.append(
+            {
+                "url": url,
+                "stream": str(path),
+                "status": record["status"],
+                "content_hash": record["content_hash"],
+                "word_count": record["word_count"],
+                "jsonld_types": record["jsonld_types"],
+            }
+        )
+
+    summary = (
+        f"{len(written)} page observation(s), {changed} changed since last pass"
+        f"{' (fixture mode)' if fixture is not None else ''}, outcome=success"
+    )
+    log_line = common.log_pass(COLLECTOR, summary, home=home)
+    return {"collector": COLLECTOR, "observations": written, "changed": changed, "log": log_line}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--url",
+        action="append",
+        dest="urls",
+        help="URL to collect (repeatable). Default: collectors.page.urls from config.yaml.",
+    )
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help="Replay recorded HTML from a file or a directory of <page-slug>.html files (offline).",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the machine-readable summary.")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = common.ensure_workspace()
+    try:
+        config = workspace.load_config(home)
+    except (OSError, ValueError) as exc:
+        return common.fail(str(exc))
+
+    urls = args.urls or list(workspace.config_get(config, "collectors.page.urls", []) or [])
+    budget = workspace.config_get(config, "budgets.pages_per_day", None)
+
+    try:
+        result = collect(
+            urls=[str(url) for url in urls],
+            home=home,
+            fixture=Path(args.fixture).expanduser() if args.fixture else None,
+            budget=int(budget) if budget else None,
+        )
+    except common.CollectorError as exc:
+        return common.fail(str(exc))
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for item in result["observations"]:
+            types = ", ".join(item["jsonld_types"]) or "no JSON-LD"
+            print(f"✓ {item['url']}: {item['word_count']} words, {types} → {item['stream']}")
+        print(result["log"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/collectors/serp.py
+++ b/collectors/serp.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""SERP collector: position history for your queries, from the Brave Search API.
+
+Deterministic, zero LLM calls. One record per query per pass, appended to
+``$EGEO_HOME/data/serp/<query-slug>.jsonl``::
+
+    {"v": 1, "ts": "...Z", "query": "...", "engine": "brave",
+     "results": [{"position": 1, "url": "...", "domain": "...", "title": "..."}, ...],
+     "target_domain": "example.com", "target_position": 3 | null}
+
+Brave is called over its HTTP API directly (``BRAVE_API_KEY``) rather than
+through the Brave MCP: a cron-launched collector has no agent, hence no MCP.
+Live passes are paced at ≤1 query/second and refuse to exceed
+``budgets.queries_per_day``.
+
+Usage::
+
+    python collectors/serp.py                       # queries from config.yaml
+    python collectors/serp.py --query "best geo tool"
+    python collectors/serp.py --fixture collectors/fixtures/serp_brave_response.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode, urlparse
+
+if __package__ in (None, ""):  # executed as a script
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import _common as common  # noqa: E402
+from egeo import workspace  # noqa: E402
+
+SCHEMA_VERSION = 1
+COLLECTOR = "serp"
+ENGINE = "brave"
+API_URL = "https://api.search.brave.com/res/v1/web/search"
+API_KEY_ENV = "BRAVE_API_KEY"
+MAX_RESULTS = 10
+MIN_SECONDS_BETWEEN_QUERIES = 1.0
+
+
+def _normalize_domain(host: str) -> str:
+    host = (host or "").strip().lower().rstrip(".")
+    return host[4:] if host.startswith("www.") else host
+
+
+def _domain_of(url: str) -> str:
+    try:
+        return _normalize_domain(urlparse(url).hostname or "")
+    except ValueError:
+        return ""
+
+
+def parse_brave_response(payload: Dict[str, Any], query: str, target_domain: str) -> Dict[str, Any]:
+    """Turn a Brave web-search body into one versioned observation record.
+
+    No interpretation: positions are the order Brave returned, the target
+    position is the first result whose domain matches, or ``None``.
+    """
+    web = payload.get("web") or {}
+    raw_results = web.get("results") or []
+    if not isinstance(raw_results, list):
+        raise common.CollectorError(f"unexpected Brave payload for {query!r}: web.results is not a list")
+
+    results: List[Dict[str, Any]] = []
+    for index, item in enumerate(raw_results[:MAX_RESULTS], start=1):
+        if not isinstance(item, dict):
+            raise common.CollectorError(f"unexpected Brave payload for {query!r}: result is not an object")
+        url = str(item.get("url", ""))
+        results.append(
+            {
+                "position": index,
+                "url": url,
+                "domain": _domain_of(url),
+                "title": str(item.get("title", "")),
+            }
+        )
+
+    target = _normalize_domain(target_domain)
+    target_position = None
+    if target:
+        for result in results:
+            if result["domain"] == target or result["domain"].endswith("." + target):
+                target_position = result["position"]
+                break
+
+    return {
+        "v": SCHEMA_VERSION,
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query": query,
+        "engine": ENGINE,
+        "results": results,
+        "target_domain": target or None,
+        "target_position": target_position,
+    }
+
+
+def fetch_brave(query: str, api_key: str, count: int = MAX_RESULTS) -> Dict[str, Any]:
+    """Call the Brave Search API and return the parsed JSON body."""
+    url = f"{API_URL}?{urlencode({'q': query, 'count': count})}"
+    status, body = common.http_get(
+        url,
+        headers={"Accept": "application/json", "X-Subscription-Token": api_key},
+    )
+    if status == 401 or status == 403:
+        raise common.CollectorError(
+            f"Brave API rejected the request (HTTP {status}). Check ${API_KEY_ENV}."
+        )
+    if status == 429:
+        raise common.CollectorError("Brave API rate limit hit (HTTP 429); retry later or lower the cadence.")
+    if status != 200:
+        raise common.CollectorError(f"Brave API returned HTTP {status} for {query!r}")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise common.CollectorError(f"Brave API returned invalid JSON for {query!r}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise common.CollectorError(f"Brave API returned a non-object body for {query!r}")
+    return payload
+
+
+def load_fixture(path: Path) -> Dict[str, Any]:
+    """Read a recorded Brave response body from disk (fixture mode)."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise common.CollectorError(f"fixture not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise common.CollectorError(f"fixture is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise common.CollectorError(f"fixture must contain a JSON object: {path}")
+    return payload
+
+
+def collect(
+    *,
+    queries: List[str],
+    target_domain: str,
+    home: Path,
+    fixture: Optional[Path] = None,
+    budget: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run one pass over ``queries``. Returns a machine-readable summary."""
+    if not queries:
+        raise common.CollectorError(
+            "no queries configured: add collectors.serp.queries to "
+            f"{home / workspace.CONFIG_NAME} or pass --query"
+        )
+
+    api_key = os.environ.get(API_KEY_ENV, "").strip()
+    if fixture is None and not api_key:
+        raise common.CollectorError(
+            f"${API_KEY_ENV} is not set. Export a Brave Search API key, or run with "
+            "--fixture <recorded-response.json> for an offline pass."
+        )
+
+    paths = {query: common.stream_path(COLLECTOR, common.slugify(query), home) for query in queries}
+    if budget:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        already = common.count_today(sorted(workspace.data_dir(COLLECTOR, home).glob("*.jsonl")), today)
+        if already + len(queries) > budget:
+            raise common.CollectorError(
+                f"budgets.queries_per_day={budget} would be exceeded: "
+                f"{already} recorded today + {len(queries)} requested. "
+                "Raise the budget in config.yaml or shorten the query list."
+            )
+
+    payload_cache = load_fixture(fixture) if fixture is not None else None
+    written: List[Dict[str, Any]] = []
+    for index, query in enumerate(queries):
+        if payload_cache is not None:
+            payload = payload_cache
+        else:
+            if index:
+                time.sleep(MIN_SECONDS_BETWEEN_QUERIES)
+            payload = fetch_brave(query, api_key)
+        record = parse_brave_response(payload, query, target_domain)
+        common.append_record(paths[query], record)
+        written.append({"query": query, "stream": str(paths[query]), "target_position": record["target_position"]})
+
+    positions = [item["target_position"] for item in written]
+    found = sum(1 for value in positions if value is not None)
+    summary = (
+        f"{len(written)} query observation(s), target ranked in {found}/{len(written)}"
+        f"{' (fixture mode)' if fixture is not None else ''}, outcome=success"
+    )
+    log_line = common.log_pass(COLLECTOR, summary, home=home)
+    return {"collector": COLLECTOR, "observations": written, "log": log_line}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--query",
+        action="append",
+        dest="queries",
+        help="Query to collect (repeatable). Default: collectors.serp.queries from config.yaml.",
+    )
+    parser.add_argument(
+        "--target-domain",
+        default=None,
+        help="Domain to report a position for. Default: collectors.serp.target_domain.",
+    )
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help="Replay a recorded Brave response JSON file instead of calling the API (offline).",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the machine-readable summary.")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    home = common.ensure_workspace()
+    try:
+        config = workspace.load_config(home)
+    except (OSError, ValueError) as exc:
+        return common.fail(str(exc))
+
+    queries = args.queries or list(workspace.config_get(config, "collectors.serp.queries", []) or [])
+    target_domain = args.target_domain or str(
+        workspace.config_get(config, "collectors.serp.target_domain", "") or ""
+    )
+    budget = workspace.config_get(config, "budgets.queries_per_day", None)
+
+    try:
+        result = collect(
+            queries=[str(query) for query in queries],
+            target_domain=target_domain,
+            home=home,
+            fixture=Path(args.fixture).expanduser() if args.fixture else None,
+            budget=int(budget) if budget else None,
+        )
+    except common.CollectorError as exc:
+        return common.fail(str(exc))
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for item in result["observations"]:
+            position = item["target_position"]
+            print(f"✓ {item['query']}: target position {position if position else '—'} → {item['stream']}")
+        print(result["log"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/egeo/cli.py
+++ b/egeo/cli.py
@@ -6,6 +6,7 @@ Runtime-agnostic entry point for the GEO pipeline. Subcommands:
 - ``evaluate``            thin wrapper over ``geo_eval.evaluate``.
 - ``optimize-prompts``    thin wrapper over ``geo_eval.optimize`` (meta-optimizer).
 - ``runtimes``            list available runtimes and their status.
+- ``loop``                loop mode: ``run``, ``collect``, ``doctor`` (see :mod:`egeo.loop`).
 
 Everything honors ``GEO_EVAL_MOCK=1`` (via ``llm_client.get_client``), so the
 CLI runs offline in CI without an API key.
@@ -73,6 +74,12 @@ def _add_optimize_parser(sub: argparse._SubParsersAction) -> None:
     p.add_argument("--rewriter-model", default=os.environ.get("REWRITER_MODEL", "gpt-4o"))
     p.add_argument("--temperature", type=float, default=0.0)
     p.add_argument("--json", action="store_true", help="Print only the machine-readable JSON summary.")
+
+
+def _cmd_loop(args: argparse.Namespace) -> int:
+    from . import loop
+
+    return loop.main(args)
 
 
 def _add_runtimes_parser(sub: argparse._SubParsersAction) -> None:
@@ -195,6 +202,9 @@ def build_parser() -> argparse.ArgumentParser:
     _add_evaluate_parser(sub)
     _add_optimize_prompts_parser(sub)
     _add_runtimes_parser(sub)
+    from . import loop
+
+    loop.add_parser(sub)
     return parser
 
 
@@ -203,6 +213,7 @@ _DISPATCH = {
     "evaluate": _cmd_evaluate,
     "optimize-prompts": _cmd_optimize_prompts,
     "runtimes": _cmd_runtimes,
+    "loop": _cmd_loop,
 }
 
 

--- a/egeo/loop.py
+++ b/egeo/loop.py
@@ -1,0 +1,448 @@
+"""``egeo loop`` — the loop-mode surface: ``run``, ``collect``, ``doctor``.
+
+Loop mode turns one-shot GEO into a continuous one: deterministic collectors
+record ground truth into a per-user workspace (``$EGEO_HOME``), and an agent run
+turns that data into knowledge, one bounded unit of work per wake-up.
+
+This module is the **trigger seam**, not the loop itself. It is LLM-free by
+design:
+
+- ``egeo loop collect <serp|page>`` runs a collector pass in-process.
+- ``egeo loop run <domain>`` resolves and prints the *run plan* — the charter's
+  current focus, collector deltas since the last Timeline entry, and candidate
+  signals — and makes sure the workspace and domain are in a valid state. The
+  interpretive work is then performed by an agent runtime executing
+  ``.claude/skills/geo-loop/SKILL.md`` (in Claude Code: ``/geo:loop <domain>``,
+  headless: ``claude -p "/geo:loop <domain>"``).
+- ``egeo loop doctor`` self-checks the workspace.
+
+Any scheduler drives these commands identically; Hermes cron is the reference.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import repo_root, substrate_lint, workspace
+
+#: Collector name → module file under ``collectors/``.
+COLLECTORS = {"serp": "serp.py", "page": "page.py"}
+
+_TIMELINE_DATE_RE = re.compile(r"^### (\d{4}-\d{2}-\d{2}) run\s*$")
+
+
+# --------------------------------------------------------------------------- #
+# collect
+# --------------------------------------------------------------------------- #
+def load_collector(name: str):
+    """Import a collector module from ``collectors/`` for in-process invocation."""
+    if name not in COLLECTORS:
+        raise KeyError(name)
+    directory = repo_root() / "collectors"
+    path = directory / COLLECTORS[name]
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    if str(directory) not in sys.path:
+        sys.path.insert(0, str(directory))  # so the module finds `_common`
+    spec = importlib.util.spec_from_file_location(f"egeo_collector_{name}", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load collector {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# run plan
+# --------------------------------------------------------------------------- #
+def parse_charter(text: str) -> Dict[str, Any]:
+    """Extract the level-2 sections and Timeline entries of a domain charter."""
+    sections: Dict[str, List[str]] = {}
+    current: Optional[str] = None
+    timeline_dates: List[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            current = line[3:].strip()
+            sections[current] = []
+            continue
+        if current == "Timeline":
+            match = _TIMELINE_DATE_RE.match(line)
+            if match:
+                timeline_dates.append(match.group(1))
+        if current:
+            sections[current].append(line)
+
+    def body(name: str) -> List[str]:
+        return [line.strip() for line in sections.get(name, []) if line.strip()]
+
+    backlog = [
+        re.sub(r"^(?:\d+\.|[-*])\s*", "", line)
+        for line in body("Backlog")
+        if re.match(r"^(?:\d+\.|[-*])\s", line)
+    ]
+    return {
+        "charter": " ".join(body("Charter")),
+        "cadence": " ".join(body("Cadence")),
+        "current_focus": " ".join(body("Current focus")),
+        "backlog": backlog,
+        "timeline_dates": timeline_dates,
+        "last_run": timeline_dates[-1] if timeline_dates else None,
+    }
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def collector_deltas(home: Path, since: Optional[str]) -> List[Dict[str, Any]]:
+    """Summarize each collector stream: totals, new records since ``since``, drift.
+
+    ``since`` is a ``YYYY-MM-DD`` date (the last Timeline entry); records with a
+    ``ts`` on or after it are "fresh". Read-only.
+    """
+    out: List[Dict[str, Any]] = []
+    data_root = home / "data"
+    if not data_root.is_dir():
+        return out
+    for stream in sorted(data_root.glob("*/*.jsonl")):
+        records = _read_jsonl(stream)
+        if not records:
+            continue
+        fresh = [r for r in records if since is None or str(r.get("ts", "")) >= since]
+        item: Dict[str, Any] = {
+            "collector": stream.parent.name,
+            "stream": stream.name[: -len(".jsonl")],
+            "records": len(records),
+            "fresh": len(fresh),
+            "latest_ts": records[-1].get("ts"),
+        }
+        if stream.parent.name == "serp":
+            positions = [r.get("target_position") for r in records]
+            item["target_position"] = positions[-1]
+            previous = next((p for p in reversed(positions[:-1]) if p is not None), None)
+            if positions[-1] is not None and previous is not None:
+                item["position_delta"] = previous - positions[-1]
+        if stream.parent.name == "page":
+            hashes = [r.get("content_hash") for r in records]
+            item["content_changed"] = len(hashes) > 1 and hashes[-1] != hashes[-2]
+            item["word_count"] = records[-1].get("word_count")
+            item["jsonld_types"] = records[-1].get("jsonld_types")
+        out.append(item)
+    return out
+
+
+def candidate_signals(deltas: List[Dict[str, Any]]) -> List[str]:
+    """Observations worth interpreting, phrased for the agent — not written here.
+
+    Deliberately conservative and mechanical: thresholds mirror loopstack
+    ARCHITECTURE.md 5.3 (position move ≥3 is signal-worthy). Turning these into
+    artifacts is the agent's job; this list only tells it where to look.
+    """
+    candidates: List[str] = []
+    for item in deltas:
+        if item["collector"] == "serp":
+            delta = item.get("position_delta")
+            if isinstance(delta, int) and abs(delta) >= 3:
+                direction = "improved" if delta > 0 else "dropped"
+                candidates.append(
+                    f"serp/{item['stream']}: target position {direction} by {abs(delta)} "
+                    f"(now {item.get('target_position')})"
+                )
+            elif item.get("target_position") is None and item["records"] >= 3:
+                candidates.append(
+                    f"serp/{item['stream']}: target absent from the top 10 across {item['records']} observations"
+                )
+        if item["collector"] == "page":
+            if item.get("content_changed"):
+                candidates.append(f"page/{item['stream']}: content hash changed since the previous pass")
+            if not item.get("jsonld_types"):
+                candidates.append(f"page/{item['stream']}: no JSON-LD detected on the page")
+    return candidates
+
+
+def build_plan(domain: str, home: Path) -> Dict[str, Any]:
+    """Assemble the run plan for ``domain``. Pure read; never writes."""
+    readme = workspace.domain_readme(domain, home)
+    plan: Dict[str, Any] = {
+        "domain": domain,
+        "workspace": str(home),
+        "charter_path": str(readme),
+        "charter_exists": readme.is_file(),
+    }
+    if readme.is_file():
+        plan.update(parse_charter(readme.read_text(encoding="utf-8")))
+    plan["deltas"] = collector_deltas(home, plan.get("last_run"))
+    plan["candidate_signals"] = candidate_signals(plan["deltas"])
+    plan["skill"] = ".claude/skills/geo-loop/SKILL.md"
+    plan["agent_command"] = f"/geo:loop {domain}"
+    return plan
+
+
+def _print_plan(plan: Dict[str, Any], dry_run: bool) -> None:
+    mode = "DRY RUN — nothing will be written" if dry_run else "run plan"
+    print(f"egeo loop run: {plan['domain']} ({mode})")
+    print(f"  workspace:     {plan['workspace']}")
+    print(f"  charter:       {plan['charter_path']}")
+    if not plan["charter_exists"]:
+        print("  charter:       MISSING — create it (see egeo-core backlog) before running the agent")
+    else:
+        print(f"  cadence:       {plan.get('cadence') or '—'}")
+        print(f"  current focus: {plan.get('current_focus') or '—'}")
+        print(f"  last run:      {plan.get('last_run') or 'never'}")
+        backlog = plan.get("backlog") or []
+        print(f"  backlog:       {len(backlog)} item(s)")
+        for item in backlog[:5]:
+            print(f"    - {item}")
+
+    deltas = plan["deltas"]
+    print(f"  fresh data:    {sum(item['fresh'] for item in deltas)} new record(s) across {len(deltas)} stream(s)")
+    for item in deltas:
+        extra = ""
+        if item["collector"] == "serp":
+            extra = f", position {item.get('target_position')}"
+            if "position_delta" in item:
+                extra += f" (delta {item['position_delta']:+d})"
+        elif item["collector"] == "page":
+            extra = f", {item.get('word_count')} words, changed={item.get('content_changed')}"
+        print(f"    - {item['collector']}/{item['stream']}: {item['fresh']}/{item['records']} fresh{extra}")
+
+    candidates = plan["candidate_signals"]
+    print(f"  candidate signals: {len(candidates)}")
+    for line in candidates:
+        print(f"    - {line}")
+
+    print("  next: one unit of work, executed by the agent, not by this command:")
+    print(f"    Claude Code:  {plan['agent_command']}")
+    print(f'    headless:     claude -p "{plan["agent_command"]}"   # pin provider+model per job')
+    print(f"    procedure:    {plan['skill']}")
+
+
+# --------------------------------------------------------------------------- #
+# doctor
+# --------------------------------------------------------------------------- #
+def diagnose(home: Path) -> Tuple[List[str], List[str], Dict[str, Any]]:
+    """Check the workspace. Returns ``(problems, warnings, facts)``.
+
+    Never prints secret values: only whether a variable is set.
+    """
+    problems: List[str] = []
+    warnings: List[str] = []
+    facts: Dict[str, Any] = {"home": str(home)}
+
+    for name in workspace.LAYOUT_DIRS:
+        if not (home / name).is_dir():
+            problems.append(f"missing directory: {name}/")
+    for name in (workspace.LOG_NAME, workspace.CONFIG_NAME, workspace.SUBSTRATE_NAME):
+        if not (home / name).is_file():
+            problems.append(f"missing file: {name}")
+
+    config: Dict[str, Any] = {}
+    try:
+        config = workspace.load_config(home)
+    except FileNotFoundError:
+        problems.append(f"{workspace.CONFIG_NAME} not found")
+    except (OSError, ValueError) as exc:
+        problems.append(f"{workspace.CONFIG_NAME} does not parse: {exc}")
+
+    if config:
+        auto_apply = workspace.config_get(config, "reflect.auto_apply", None)
+        facts["reflect.auto_apply"] = auto_apply
+        if auto_apply not in ("never", "low_risk", "all"):
+            problems.append(f"reflect.auto_apply must be never|low_risk|all, got {auto_apply!r}")
+        for key in ("budgets.queries_per_day", "budgets.pages_per_day"):
+            value = workspace.config_get(config, key, None)
+            facts[key] = value
+            if value is None:
+                warnings.append(f"{key} is unset: collectors will run without a cap")
+            elif not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                problems.append(f"{key} must be a positive integer, got {value!r}")
+        facts["models"] = workspace.config_get(config, "models", {})
+
+    violations, artifacts, domains = substrate_lint.lint(home)
+    facts["artifacts"] = artifacts
+    facts["domains"] = domains
+    for path, line, message in violations:
+        problems.append(f"substrate {path}:{line}: {message}")
+
+    facts["brave_api_key_set"] = bool(os.environ.get("BRAVE_API_KEY", "").strip())
+    if not facts["brave_api_key_set"]:
+        warnings.append("BRAVE_API_KEY is not set: the serp collector can only run in --fixture mode")
+
+    overrides = sorted(p.name for p in workspace.prompts_dir(home).glob("*.txt")) if workspace.prompts_dir(home).is_dir() else []
+    facts["prompt_overrides"] = overrides
+
+    repo_substrate = repo_root() / workspace.SUBSTRATE_NAME
+    workspace_substrate = home / workspace.SUBSTRATE_NAME
+    if repo_substrate.is_file() and workspace_substrate.is_file():
+        drift = repo_substrate.read_text(encoding="utf-8") != workspace_substrate.read_text(encoding="utf-8")
+        facts["substrate_drift"] = drift
+        if drift:
+            warnings.append(
+                "workspace SUBSTRATE.md differs from the repo copy: review the contract, "
+                "then replace the workspace copy to adopt it"
+            )
+
+    streams = sorted((home / "data").glob("*/*.jsonl")) if (home / "data").is_dir() else []
+    facts["streams"] = len(streams)
+    return problems, warnings, facts
+
+
+# --------------------------------------------------------------------------- #
+# command handlers
+# --------------------------------------------------------------------------- #
+def cmd_run(args: argparse.Namespace) -> int:
+    home = workspace.resolve_home()
+    if args.dry_run:
+        if not workspace.exists(home):
+            print(
+                f"egeo loop run: {home} is not bootstrapped yet (dry run writes nothing).\n"
+                "Run `egeo loop doctor` to create the workspace.",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        workspace.bootstrap(home)
+
+    plan = build_plan(args.domain, home)
+    if args.json:
+        print(json.dumps(plan, indent=2, sort_keys=True))
+    else:
+        _print_plan(plan, args.dry_run)
+    if not plan["charter_exists"]:
+        return 1
+    return 0
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    workspace.bootstrap(workspace.resolve_home())
+    module = load_collector(args.collector)
+    argv = list(args.collector_args)
+    if argv and argv[0] == "--":  # argparse.REMAINDER keeps the separator
+        argv = argv[1:]
+    return int(module.main(argv))
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    home = workspace.resolve_home()
+    summary = workspace.bootstrap(home)
+    problems, warnings, facts = diagnose(home)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "bootstrapped_now": summary["bootstrapped"],
+                    "created": summary["created"],
+                    "facts": facts,
+                    "warnings": warnings,
+                    "problems": problems,
+                    "ok": not problems,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 1 if problems else 0
+
+    print(f"egeo loop doctor — {facts['home']}")
+    if summary["bootstrapped"]:
+        print(f"  bootstrapped now: {', '.join(summary['created'])}")
+    else:
+        print("  workspace: already present (bootstrap left it untouched)")
+    print(f"  substrate: {facts.get('artifacts', 0)} artifact(s), {facts.get('domains', 0)} domain(s), "
+          f"{facts.get('streams', 0)} data stream(s)")
+    print(f"  budgets:   queries/day={facts.get('budgets.queries_per_day')} "
+          f"pages/day={facts.get('budgets.pages_per_day')}")
+    print(f"  reflect:   auto_apply={facts.get('reflect.auto_apply')}")
+    print(f"  BRAVE_API_KEY: {'set' if facts.get('brave_api_key_set') else 'not set'}")
+    overrides = facts.get("prompt_overrides") or []
+    print(f"  prompt overrides: {', '.join(overrides) if overrides else 'none (repo defaults in use)'}")
+    for warning in warnings:
+        print(f"  WARN: {warning}")
+    for problem in problems:
+        print(f"  FAIL: {problem}", file=sys.stderr)
+    if problems:
+        print(f"{len(problems)} problem(s) found.", file=sys.stderr)
+        return 1
+    print("OK: workspace is healthy.")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# parser
+# --------------------------------------------------------------------------- #
+def add_parser(sub: argparse._SubParsersAction) -> None:
+    """Register the ``loop`` subcommand group on the ``egeo`` parser."""
+    parser = sub.add_parser(
+        "loop",
+        help="Loop mode: collectors, run plans, and workspace health ($EGEO_HOME).",
+        description=(
+            "Loop mode keeps state in a per-user workspace ($EGEO_HOME, default ~/.egeo). "
+            "These commands are the scheduler seam and make zero LLM calls: `collect` gathers "
+            "ground truth, `run` resolves the plan for one unit of work, `doctor` checks the "
+            "workspace. The interpretive loop run itself is executed by an agent runtime via "
+            ".claude/skills/geo-loop/SKILL.md (`/geo:loop <domain>`)."
+        ),
+    )
+    loop_sub = parser.add_subparsers(dest="loop_cmd", required=True)
+
+    run = loop_sub.add_parser(
+        "run",
+        help="Resolve and print the run plan for one domain (the agent does the work).",
+        description=(
+            "Prints the domain's current focus, collector deltas since its last Timeline entry, "
+            "and candidate signals, then names the agent command that performs the unit of work. "
+            "With --dry-run nothing is written at all."
+        ),
+    )
+    run.add_argument("domain", help="Domain directory name under $EGEO_HOME/domains/.")
+    run.add_argument("--dry-run", action="store_true", help="Print the plan and write nothing (not even bootstrap).")
+    run.add_argument("--json", action="store_true", help="Print the plan as JSON.")
+    run.set_defaults(loop_handler=cmd_run)
+
+    collect = loop_sub.add_parser(
+        "collect",
+        help="Run one deterministic collector pass (no LLM calls).",
+        description=(
+            "Runs a collector in-process against $EGEO_HOME. Every argument after the collector "
+            "name is forwarded to it verbatim, so `--fixture`, `--json`, `--query` and `--url` "
+            "behave exactly as when running collectors/<name>.py directly; "
+            "`egeo loop collect serp --help` shows them."
+        ),
+    )
+    collect.add_argument("collector", choices=sorted(COLLECTORS), help="Collector to run.")
+    collect.add_argument(
+        "collector_args",
+        nargs=argparse.REMAINDER,
+        metavar="...",
+        help="Arguments forwarded to the collector (e.g. --fixture PATH, --query Q, --url URL, --json).",
+    )
+    collect.set_defaults(loop_handler=cmd_collect)
+
+    doctor = loop_sub.add_parser(
+        "doctor",
+        help="Bootstrap if needed, then self-check the workspace (layout, config, substrate, budgets).",
+    )
+    doctor.add_argument("--json", action="store_true", help="Print the diagnosis as JSON.")
+    doctor.set_defaults(loop_handler=cmd_doctor)
+
+
+def main(args: argparse.Namespace) -> int:
+    """Dispatch a parsed ``egeo loop ...`` namespace."""
+    return int(args.loop_handler(args))
+
+
+__all__ = ["add_parser", "main", "build_plan", "diagnose", "load_collector", "parse_charter"]

--- a/egeo/substrate_lint.py
+++ b/egeo/substrate_lint.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Substrate lint: enforce the contract defined in the vendored ``SUBSTRATE.md``.
+
+Checks artifacts under ``signals/`` and ``docs/``, domain charters under
+``domains/``, and the ``LOG.md`` line grammar of a substrate root — for E-GEO,
+the loop workspace (``$EGEO_HOME``). Prints one ``path:line: message`` per
+violation and exits 1 if there is any. Python standard library only, by design:
+the frontmatter subset in SUBSTRATE.md 2 is small enough to parse by hand, and
+the lint must run anywhere with no install step.
+
+Adapted from ``scripts/substrate_lint.py`` in mverab/loopstack (the upstream
+system repo that owns the contract); kept in sync when SUBSTRATE.md is re-vendored.
+The only local changes are this docstring, the default root (the workspace
+instead of the repo), and :func:`lint` so ``egeo loop doctor`` can call it as a
+library instead of shelling out.
+
+Usage: python3 -m egeo.substrate_lint [substrate-root]
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+KINDS = ("signal", "doc")
+CONFIDENCES = ("high", "medium", "low")
+REQUIRED_FIELDS = ("kind", "domains", "created", "updated", "confidence", "sources")
+KIND_DIRS = {"signals": "signal", "docs": "doc"}
+DOMAIN_SECTIONS = ("Charter", "Cadence", "Current focus", "Backlog", "Timeline")
+OUTCOMES = ("success", "partial", "failure", "no-op")
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+LOG_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z) "
+    r"\[(?P<domain>[a-z0-9][a-z0-9-]*)\] "
+    r"(?P<event>[a-z0-9][a-z0-9-]*): "
+    r"(?P<summary>\S.*)$"
+)
+OUTCOME_RE = re.compile(r"outcome=([a-z-]+)$")
+
+
+class Errors:
+    def __init__(self):
+        self.items = []
+
+    def add(self, path, line, message):
+        self.items.append((str(path), line, message))
+
+    def report(self):
+        for path, line, message in sorted(self.items, key=lambda item: (item[0], item[1])):
+            print(f"{path}:{line}: {message}")
+        return 1 if self.items else 0
+
+
+def split_frontmatter(text):
+    """Return (fields, body_start_line, error) for a leading --- block.
+
+    fields maps name -> (raw_value, line_number). Values are either a scalar
+    string or a list of strings (inline `[a, b]` form only).
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, 0, "missing YAML frontmatter (file must start with '---')"
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return None, 0, "unterminated YAML frontmatter (no closing '---')"
+
+    fields = {}
+    for i in range(1, end):
+        raw = lines[i]
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if ":" not in raw:
+            return None, i + 1, f"frontmatter line is not 'key: value': {raw.strip()!r}"
+        key, _, value = raw.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if not key or key != raw.partition(":")[0]:
+            return None, i + 1, f"frontmatter key must be unindented: {raw.strip()!r}"
+        if key in fields:
+            return None, i + 1, f"duplicate frontmatter field '{key}'"
+        if value.startswith("["):
+            if not value.endswith("]"):
+                return None, i + 1, (
+                    f"field '{key}': only single-line inline lists are supported "
+                    f"(got {value!r})"
+                )
+            inner = value[1:-1].strip()
+            parsed = [v.strip() for v in inner.split(",") if v.strip()] if inner else []
+        else:
+            parsed = value
+        fields[key] = (parsed, i + 1)
+    return fields, end + 2, None
+
+
+def check_artifact(path, root, domains, errors):
+    text = path.read_text(encoding="utf-8")
+    fields, _, err = split_frontmatter(text)
+    rel = path.relative_to(root)
+    if err:
+        errors.add(rel, 1, err)
+        return
+
+    for name in REQUIRED_FIELDS:
+        if name not in fields:
+            errors.add(rel, 1, f"missing required frontmatter field '{name}'")
+
+    def get(name):
+        return fields[name][0] if name in fields else None
+
+    def line_of(name):
+        return fields[name][1] if name in fields else 1
+
+    kind = get("kind")
+    if kind is not None:
+        if isinstance(kind, list) or kind not in KINDS:
+            errors.add(
+                rel,
+                line_of("kind"),
+                f"field 'kind': {kind!r} is not one of {list(KINDS)} "
+                f"(new kinds must be earned, see SUBSTRATE.md 6)",
+            )
+        else:
+            expected = KIND_DIRS.get(rel.parts[0])
+            if expected and kind != expected:
+                errors.add(
+                    rel,
+                    line_of("kind"),
+                    f"field 'kind': {kind!r} does not match directory "
+                    f"'{rel.parts[0]}/' (expected {expected!r})",
+                )
+
+    doms = get("domains")
+    if doms is not None:
+        if not isinstance(doms, list) or not doms:
+            errors.add(rel, line_of("domains"), "field 'domains': must be a non-empty list")
+        else:
+            for d in doms:
+                if d not in domains:
+                    errors.add(
+                        rel,
+                        line_of("domains"),
+                        f"field 'domains': '{d}' has no directory under domains/",
+                    )
+
+    for name in ("created", "updated"):
+        value = get(name)
+        if value is not None and (isinstance(value, list) or not DATE_RE.match(value)):
+            errors.add(rel, line_of(name), f"field '{name}': expected YYYY-MM-DD, got {value!r}")
+    created, updated = get("created"), get("updated")
+    if (
+        isinstance(created, str)
+        and isinstance(updated, str)
+        and DATE_RE.match(created)
+        and DATE_RE.match(updated)
+        and updated < created
+    ):
+        errors.add(rel, line_of("updated"), f"field 'updated' ({updated}) is earlier than 'created' ({created})")
+
+    confidence = get("confidence")
+    if confidence is not None and (isinstance(confidence, list) or confidence not in CONFIDENCES):
+        errors.add(
+            rel,
+            line_of("confidence"),
+            f"field 'confidence': {confidence!r} is not one of {list(CONFIDENCES)}",
+        )
+
+    sources = get("sources")
+    if sources is not None:
+        if not isinstance(sources, list):
+            errors.add(rel, line_of("sources"), "field 'sources': must be a list")
+        elif not sources and confidence != "low":
+            errors.add(
+                rel,
+                line_of("sources"),
+                "field 'sources': may be empty only when confidence is 'low'",
+            )
+
+    if "frequency" in fields:
+        freq = get("frequency")
+        if kind != "signal":
+            errors.add(rel, line_of("frequency"), "field 'frequency': valid on signals only")
+        elif isinstance(freq, list) or not freq.isdigit() or int(freq) < 1:
+            errors.add(rel, line_of("frequency"), f"field 'frequency': expected an integer >= 1, got {freq!r}")
+    elif kind == "signal":
+        errors.add(rel, 1, "missing frontmatter field 'frequency' (required on signals)")
+
+
+def check_domain(readme, root, errors):
+    rel = readme.relative_to(root)
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    if lines and lines[0].strip() == "---":
+        errors.add(rel, 1, "domain README is a charter, not an artifact: it must have no frontmatter")
+
+    found = []
+    for i, line in enumerate(lines):
+        if line.startswith("## "):
+            found.append((line[3:].strip(), i + 1))
+    names = [n for n, _ in found]
+    for section in DOMAIN_SECTIONS:
+        if section not in names:
+            errors.add(rel, 1, f"missing required section '## {section}'")
+    present = [n for n in names if n in DOMAIN_SECTIONS]
+    expected_order = [s for s in DOMAIN_SECTIONS if s in present]
+    if present != expected_order:
+        errors.add(rel, 1, f"sections out of order: expected {expected_order}, got {present}")
+    if present and present[-1] != "Timeline" and "Timeline" in present:
+        errors.add(rel, 1, "'## Timeline' must be the last section of the domain README")
+
+    timeline_line = next((ln for n, ln in found if n == "Timeline"), None)
+    if timeline_line is not None:
+        for i in range(timeline_line, len(lines)):
+            if lines[i].startswith("### "):
+                header = lines[i][4:].strip()
+                if not re.match(r"^\d{4}-\d{2}-\d{2} run$", header):
+                    errors.add(rel, i + 1, f"timeline entry header must be '### YYYY-MM-DD run', got {header!r}")
+        entries = [i for i in range(timeline_line, len(lines)) if lines[i].startswith("### ")]
+        for start_index, start in enumerate(entries):
+            end = entries[start_index + 1] if start_index + 1 < len(entries) else len(lines)
+            body = [ln.strip() for ln in lines[start + 1:end] if ln.strip()]
+            outcome = next((ln for ln in body if ln.startswith("Outcome:")), None)
+            if outcome is None:
+                errors.add(rel, start + 1, "timeline entry has no 'Outcome:' line")
+            else:
+                value = outcome[len("Outcome:"):].strip()
+                if value not in OUTCOMES:
+                    errors.add(
+                        rel,
+                        start + 1,
+                        f"timeline entry Outcome: {value!r} is not one of {list(OUTCOMES)}",
+                    )
+                elif body[-1] != outcome:
+                    errors.add(rel, start + 1, "the 'Outcome:' line must be the last line of the timeline entry")
+
+
+def check_log(path, root, domains, errors):
+    rel = path.relative_to(root)
+    in_comment = False
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
+        stripped = line.strip()
+        if in_comment:
+            if stripped.endswith("-->"):
+                in_comment = False
+            continue
+        if stripped.startswith("<!--"):
+            if not stripped.endswith("-->"):
+                in_comment = True
+            continue
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = LOG_RE.match(line)
+        if not match:
+            errors.add(
+                rel,
+                i + 1,
+                "line does not match '<YYYY-MM-DDTHH:MMZ> [<domain>] <event>: <summary>': "
+                f"{stripped!r}",
+            )
+            continue
+        domain = match.group("domain")
+        if domains and domain not in domains:
+            errors.add(rel, i + 1, f"unknown domain '{domain}' (no directory under domains/)")
+        outcome = OUTCOME_RE.search(match.group("summary"))
+        if outcome and outcome.group(1) not in OUTCOMES:
+            errors.add(rel, i + 1, f"outcome={outcome.group(1)!r} is not one of {list(OUTCOMES)}")
+
+
+def lint(root) -> Tuple[List[Tuple[str, int, str]], int, int]:
+    """Lint a substrate root as a library call.
+
+    Returns ``(violations, artifact_count, domain_count)`` where each violation is
+    ``(path, line, message)``. Nothing is printed, so callers such as
+    ``egeo loop doctor`` can format the result themselves.
+    """
+    root = Path(root).resolve()
+    errors = _collect(root)
+    return errors.items, errors.checked, errors.domains
+
+
+def _collect(root):
+    errors = Errors()
+    errors.checked = 0
+    errors.domains = 0
+
+    domains_dir = root / "domains"
+    domains = sorted(p.name for p in domains_dir.iterdir() if p.is_dir()) if domains_dir.is_dir() else []
+
+    for name in domains:
+        readme = domains_dir / name / "README.md"
+        if not readme.is_file():
+            errors.add(Path("domains") / name, 1, "domain directory has no README.md charter")
+        else:
+            check_domain(readme, root, errors)
+
+    checked = 0
+    for kind_dir in KIND_DIRS:
+        directory = root / kind_dir
+        if not directory.is_dir():
+            errors.add(Path(kind_dir), 1, "required substrate directory is missing")
+            continue
+        for path in sorted(directory.rglob("*.md")):
+            check_artifact(path, root, domains, errors)
+            checked += 1
+
+    log = root / "LOG.md"
+    if not log.is_file():
+        errors.add(Path("LOG.md"), 1, "required global activity feed is missing")
+    else:
+        check_log(log, root, domains, errors)
+
+    errors.checked = checked
+    errors.domains = len(domains)
+    return errors
+
+
+def main(argv):
+    from . import workspace
+
+    root = Path(argv[1]).resolve() if len(argv) > 1 else workspace.resolve_home()
+    errors = _collect(root)
+
+    status = errors.report()
+    if status == 0:
+        print(
+            f"substrate ok: {errors.checked} artifact(s), {errors.domains} domain(s), LOG.md valid"
+        )
+    else:
+        print(f"substrate lint failed: {len(errors.items)} error(s)", file=sys.stderr)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/egeo/workspace.py
+++ b/egeo/workspace.py
@@ -1,0 +1,348 @@
+"""The E-GEO loop workspace: `$EGEO_HOME` resolution and idempotent bootstrap.
+
+Loop *code* ships in this repository; loop *state* lives in a per-user workspace
+outside it, so ``git pull`` can never clobber accumulated memory and private
+data (SERP history, client domains) can never leak into a public fork. The
+workspace layout is the substrate contract vendored at ``SUBSTRATE.md``::
+
+    $EGEO_HOME/
+    ├── LOG.md                        # append-only activity feed, one line per event
+    ├── config.yaml                   # loop machinery: cadence, models, budgets
+    ├── SUBSTRATE.md                  # the contract, copied at bootstrap
+    ├── signals/<slug>.md             # kind: signal   (evidence, deduped)
+    ├── docs/<slug>.md                # kind: doc      (durable knowledge)
+    ├── data/<collector>/*.jsonl      # collector output (not artifacts)
+    ├── domains/<loop>/README.md      # charter + Timeline
+    └── prompts/*.txt                 # optimized prompt overrides
+
+Everything that touches loop state — collectors, ``egeo loop``, and the
+workspace-first prompt resolution in :mod:`geo_eval` — resolves paths through
+this module, so there is exactly one definition of "where state lives".
+
+Nothing here is required for one-shot mode: with no workspace on disk, ``/geo``
+and ``egeo optimize`` behave exactly as before loop mode existed.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from . import repo_root
+
+#: Environment variable that overrides the default workspace location.
+HOME_ENV = "EGEO_HOME"
+
+#: Workspace location used when :data:`HOME_ENV` is unset.
+DEFAULT_HOME = "~/.egeo"
+
+#: Directories created by :func:`bootstrap` (substrate layout + prompt overrides).
+LAYOUT_DIRS = ("signals", "docs", "data", "domains", "prompts")
+
+#: Domain that owns workspace machinery events (bootstrap, collector passes), so
+#: every LOG.md line names an existing directory under ``domains/`` per SUBSTRATE.md 7.
+MACHINERY_DOMAIN = "egeo-core"
+
+CONFIG_NAME = "config.yaml"
+LOG_NAME = "LOG.md"
+SUBSTRATE_NAME = "SUBSTRATE.md"
+
+_LOG_HEADER = """# LOG
+
+<!--
+Append-only activity feed for this E-GEO workspace: one line per event, oldest
+first, so concurrent writers merge cleanly. Grammar (SUBSTRATE.md 7):
+
+  <YYYY-MM-DDTHH:MMZ> [<domain>] <event>: <summary>
+
+Summaries for completed units of work end in
+outcome=<success|partial|failure|no-op>. Only lines matching that grammar are
+valid; headings and comment blocks like this one are ignored by the parser.
+-->
+"""
+
+_CORE_CHARTER = """# egeo-core
+
+## Charter
+
+Housekeeping loop for this E-GEO workspace itself. It owns workspace machinery
+events (bootstrap, collector passes, doctor findings) so every `LOG.md` line has
+a real domain, and it is where you record work about the loop rather than about
+a site. Create one domain directory per site or client you optimize; keep this
+one for the plumbing.
+
+## Cadence
+
+On demand — this domain has no scheduled agent run of its own.
+
+## Current focus
+
+Keep the workspace substrate valid (`egeo loop doctor` clean).
+
+## Backlog
+
+1. Add a domain for the first site to optimize (`domains/<site-slug>/README.md`).
+2. Fill `collectors.serp.queries` and `collectors.page.urls` in `config.yaml`.
+3. Schedule the collector and loop-run jobs.
+
+## Timeline
+"""
+
+_CONFIG_TEMPLATE = """# E-GEO loop configuration. This file is yours: the repo never overwrites it.
+# Paths are relative to this workspace ($EGEO_HOME).
+
+# How often each trigger class is expected to run. Informational: the scheduler
+# (Hermes cron, system cron, manual) is the source of truth; `egeo loop doctor`
+# only checks these are sane.
+cadence:
+  collect_serp: daily
+  collect_page: daily
+  loop_run: weekly
+  digest: weekly
+
+# Models each component expects, so doctor can flag scheduler/env mismatches.
+models:
+  ranker: gpt-4o
+  rewriter: gpt-4o
+  meta: gpt-4o
+
+# Hard caps. Collectors fail loudly rather than silently truncating.
+budgets:
+  queries_per_day: 50
+  pages_per_day: 100
+
+# Self-improvement autonomy. `never` means proposals are only ever applied by a
+# human. Widening this is a deliberate one-line change.
+reflect:
+  auto_apply: never
+
+# Weights used when the loop scores which unit of work to do next.
+scaling:
+  weights:
+    freshness: 0.4
+    frequency: 0.3
+    impact: 0.3
+
+# Collector inputs. Add your own queries and URLs.
+collectors:
+  serp:
+    target_domain: example.com
+    queries: []
+  page:
+    urls: []
+"""
+
+
+def resolve_home() -> Path:
+    """Return the workspace path from ``$EGEO_HOME``, defaulting to ``~/.egeo``.
+
+    The path is expanded and absolutised but not created; use :func:`bootstrap`
+    for that. This is the single resolution point for the whole system.
+    """
+    raw = os.environ.get(HOME_ENV) or DEFAULT_HOME
+    return Path(raw).expanduser().resolve()
+
+
+def exists(home: Optional[Path] = None) -> bool:
+    """True when a bootstrapped workspace is present (loop mode is enabled)."""
+    home = home or resolve_home()
+    return (home / LOG_NAME).is_file()
+
+
+def prompts_dir(home: Optional[Path] = None) -> Path:
+    """Path of the workspace prompt overrides (may not exist)."""
+    return (home or resolve_home()) / "prompts"
+
+
+def data_dir(collector: str, home: Optional[Path] = None) -> Path:
+    """Path of a collector's JSONL stream directory (may not exist)."""
+    return (home or resolve_home()) / "data" / collector
+
+
+def domains_dir(home: Optional[Path] = None) -> Path:
+    """Path of the domain charters directory (may not exist)."""
+    return (home or resolve_home()) / "domains"
+
+
+def domain_readme(domain: str, home: Optional[Path] = None) -> Path:
+    """Path of a domain's charter README (may not exist)."""
+    return domains_dir(home) / domain / "README.md"
+
+
+def utc_stamp() -> str:
+    """Now, as the minute-precision UTC timestamp required by SUBSTRATE.md 7."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%MZ")
+
+
+def bootstrap(home: Optional[Path] = None) -> Dict[str, Any]:
+    """Create the workspace layout if missing. Idempotent and non-destructive.
+
+    Existing files are never rewritten, so a re-run over a populated workspace
+    leaves every byte in place. Returns a summary with the resolved ``home``,
+    whether this call created the workspace, and the relative paths created.
+    """
+    home = home or resolve_home()
+    created: List[str] = []
+    fresh = not (home / LOG_NAME).is_file()
+
+    if not home.is_dir():
+        home.mkdir(parents=True, exist_ok=True)
+        created.append(".")
+    for name in LAYOUT_DIRS:
+        directory = home / name
+        if not directory.is_dir():
+            directory.mkdir(parents=True, exist_ok=True)
+            created.append(f"{name}/")
+
+    config = home / CONFIG_NAME
+    if not config.is_file():
+        config.write_text(_CONFIG_TEMPLATE, encoding="utf-8")
+        created.append(CONFIG_NAME)
+
+    substrate_src = repo_root() / SUBSTRATE_NAME
+    substrate_dst = home / SUBSTRATE_NAME
+    if not substrate_dst.is_file() and substrate_src.is_file():
+        substrate_dst.write_text(substrate_src.read_text(encoding="utf-8"), encoding="utf-8")
+        created.append(SUBSTRATE_NAME)
+
+    charter = home / "domains" / MACHINERY_DOMAIN / "README.md"
+    if not charter.is_file():
+        charter.parent.mkdir(parents=True, exist_ok=True)
+        charter.write_text(_CORE_CHARTER, encoding="utf-8")
+        created.append(f"domains/{MACHINERY_DOMAIN}/README.md")
+
+    log = home / LOG_NAME
+    if not log.is_file():
+        log.write_text(_LOG_HEADER, encoding="utf-8")
+        created.append(LOG_NAME)
+
+    if fresh:
+        append_log(
+            MACHINERY_DOMAIN,
+            "bootstrap",
+            f"created substrate layout at {home}, outcome=success",
+            home=home,
+        )
+
+    return {"home": str(home), "bootstrapped": fresh, "created": created}
+
+
+def append_log(domain: str, event: str, summary: str, home: Optional[Path] = None) -> str:
+    """Append exactly one line to the workspace ``LOG.md`` and return it.
+
+    ``domain`` must be a directory name under ``domains/`` (SUBSTRATE.md 7);
+    machinery events that belong to no single loop use
+    :data:`MACHINERY_DOMAIN`, whose charter is created at bootstrap.
+    """
+    home = home or resolve_home()
+    log = home / LOG_NAME
+    if not log.is_file():
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(_LOG_HEADER, encoding="utf-8")
+    line = f"{utc_stamp()} [{domain}] {event}: {summary}"
+    with log.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+    return line
+
+
+def load_config(home: Optional[Path] = None) -> Dict[str, Any]:
+    """Parse the workspace ``config.yaml``.
+
+    Uses PyYAML when importable (it is already a declared project dependency)
+    and falls back to a small parser covering the documented config subset —
+    nested mappings, scalars and inline/dash lists — so collectors keep working
+    in a bare-stdlib environment. Raises ``FileNotFoundError`` when there is no
+    config, and ``ValueError`` when it does not parse to a mapping.
+    """
+    home = home or resolve_home()
+    path = home / CONFIG_NAME
+    text = path.read_text(encoding="utf-8")  # FileNotFoundError is the honest error
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        data: Any = _parse_simple_yaml(text)
+    else:
+        data = yaml.safe_load(text)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: config must parse to a mapping, got {type(data).__name__}")
+    return data
+
+
+def config_get(config: Dict[str, Any], dotted: str, default: Any = None) -> Any:
+    """Read ``a.b.c`` out of a parsed config, returning ``default`` if absent."""
+    node: Any = config
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return default if node is None else node
+
+
+def _coerce(value: str) -> Any:
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [_coerce(v) for v in inner.split(",") if v.strip()] if inner else []
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered in ("true", "false"):
+        return lowered == "true"
+    if lowered in ("null", "~", ""):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_simple_yaml(text: str) -> Dict[str, Any]:
+    """Parse the config subset documented in the template (no PyYAML needed).
+
+    Supports nested mappings by indentation, scalars, inline lists and
+    dash-prefixed list items. Anything richer requires PyYAML.
+    """
+    root: Dict[str, Any] = {}
+    # Each frame is [indent, container, parent, key]: parent/key let an empty
+    # mapping be replaced by a list the first time a dash item shows up under it.
+    stack: List[List[Any]] = [[-1, root, None, None]]
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        line = line.split(" #", 1)[0].rstrip()
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        while len(stack) > 1 and indent <= stack[-1][0]:
+            stack.pop()
+        frame = stack[-1]
+        container = frame[1]
+
+        if stripped.startswith("- "):
+            if isinstance(container, dict) and not container and frame[2] is not None:
+                container = []
+                frame[1] = container
+                frame[2][frame[3]] = container
+            if isinstance(container, list):
+                container.append(_coerce(stripped[2:]))
+            continue
+
+        if ":" not in stripped or not isinstance(container, dict):
+            continue
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value == "":
+            child: Dict[str, Any] = {}
+            container[key] = child
+            stack.append([indent, child, container, key])
+        else:
+            container[key] = _coerce(value)
+    return root

--- a/geo_eval.py
+++ b/geo_eval.py
@@ -3,6 +3,7 @@ import json
 import math
 import os
 import random
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -27,6 +28,40 @@ class QueryExample:
 
 def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _workspace_prompts_dir() -> Optional[Path]:
+    """Return ``$EGEO_HOME/prompts`` when a bootstrapped workspace exists."""
+    try:
+        from egeo import workspace
+    except Exception:
+        return None
+    try:
+        if not workspace.exists():
+            return None
+        return workspace.prompts_dir()
+    except Exception:
+        return None
+
+
+def _resolve_prompt(prompts_dir: Path, name: str) -> Path:
+    """Resolve a prompt file, preferring a workspace override.
+
+    Loop mode keeps mutable prompts in ``$EGEO_HOME/prompts`` so the repo tree
+    stays read-only. When no workspace exists the repo ``prompts/`` directory is
+    used unchanged.
+    """
+    workspace_prompts = _workspace_prompts_dir()
+    if workspace_prompts is not None:
+        override = workspace_prompts / name
+        if override.is_file():
+            print(f"[egeo] prompt override: {name} <- {override}", file=sys.stderr)
+            return override
+    return prompts_dir / name
+
+
+def _read_prompt(prompts_dir: Path, name: str) -> str:
+    return _read_text(_resolve_prompt(prompts_dir, name))
 
 
 def _render_template(text: str, values: Dict[str, str]) -> str:
@@ -162,10 +197,10 @@ def evaluate(
 ) -> Dict[str, Any]:
     client = get_client()
 
-    ranker_system = _read_text(prompts_dir / "ranker_system.txt")
-    ranker_user = _read_text(prompts_dir / "ranker_user.txt")
-    rewriter_system = _read_text(prompts_dir / "rewriter_system.txt")
-    rewriter_user = _read_text(prompts_dir / "rewriter_user.txt")
+    ranker_system = _read_prompt(prompts_dir, "ranker_system.txt")
+    ranker_user = _read_prompt(prompts_dir, "ranker_user.txt")
+    rewriter_system = _read_prompt(prompts_dir, "rewriter_system.txt")
+    rewriter_user = _read_prompt(prompts_dir, "rewriter_user.txt")
 
     examples = _load_dataset(dataset_path, limit=limit)
     rng = random.Random(seed)
@@ -267,15 +302,15 @@ def optimize(
 ) -> Dict[str, Any]:
     client = get_client()
 
-    ranker_system = _read_text(prompts_dir / "ranker_system.txt")
-    ranker_user = _read_text(prompts_dir / "ranker_user.txt")
-    rewriter_system = _read_text(prompts_dir / "rewriter_system.txt")
+    ranker_system = _read_prompt(prompts_dir, "ranker_system.txt")
+    ranker_user = _read_prompt(prompts_dir, "ranker_user.txt")
+    rewriter_system = _read_prompt(prompts_dir, "rewriter_system.txt")
 
-    rewriter_user_path = prompts_dir / "rewriter_user.txt"
+    rewriter_user_path = _resolve_prompt(prompts_dir, "rewriter_user.txt")
     current_prompt = _read_text(rewriter_user_path)
 
-    meta_system = _read_text(prompts_dir / "meta_optimizer_system.txt")
-    meta_user_tpl = _read_text(prompts_dir / "meta_optimizer_user.txt")
+    meta_system = _read_prompt(prompts_dir, "meta_optimizer_system.txt")
+    meta_user_tpl = _read_prompt(prompts_dir, "meta_optimizer_user.txt")
 
     history: List[Dict[str, Any]] = []
     best_val: Optional[Dict[str, Any]] = None
@@ -377,11 +412,14 @@ def optimize(
 
     # Non-destructive by default: write the optimized prompt to a sibling
     # ``*.candidate.txt`` file so the working prompt is never silently
-    # overwritten. Use ``--apply`` to promote the candidate in place.
+    # overwritten. Use ``--apply`` to promote the candidate in place. In loop
+    # mode the destination is ``$EGEO_HOME/prompts`` so the repo tree is never
+    # written to.
+    out_dir = _workspace_prompts_dir() or prompts_dir
     if apply:
-        out_path = rewriter_user_path
+        out_path = out_dir / "rewriter_user.txt"
     else:
-        out_path = rewriter_user_path.with_suffix(".candidate.txt")
+        out_path = out_dir / "rewriter_user.candidate.txt"
     out_path.write_text(best_val["prompt"], encoding="utf-8")
     return {
         "best": best_val,

--- a/openspec/changes/add-geo-loop/design.md
+++ b/openspec/changes/add-geo-loop/design.md
@@ -1,0 +1,118 @@
+# Design: Loop Mode for E-GEO v2.0
+
+## Context
+
+The upstream design (`loopstack`, `phase-2-egeoagents-loop-integration`) was
+written against E-GEO v1, which had no CLI package: it proposed a new top-level
+`egeo_loop.py` script. This repo is now v2.0 and already ships the `egeo`
+package (`cli.py`, `runtimes.py`, `agents.py`, `pipeline.py`) with an argparse
+subcommand pattern and offline `GEO_EVAL_MOCK=1` execution. This design adapts
+the upstream contract to that reality; the *requirements* are unchanged, only
+their surface is.
+
+## Architecture
+
+```text
+scheduler (Hermes cron of record; system cron / manual work identically)
+  ├── high-freq:  python -m egeo loop collect serp     # deliver=local
+  ├── high-freq:  python -m egeo loop collect page     # deliver=local
+  ├── low-freq:   claude -p "/geo:loop <domain>"       # provider+model pinned
+  └── weekly:     digest of $EGEO_HOME/LOG.md → owner
+
+repo (code, versioned)                $EGEO_HOME (state, per user, default ~/.egeo/)
+  egeo/loop.py       ───────────────►  LOG.md, config.yaml, SUBSTRATE.md,
+  egeo/workspace.py                    signals/, docs/, data/<collector>/*.jsonl,
+  egeo/substrate_lint.py               domains/<loop>/README.md, prompts/
+  collectors/{serp,page}.py
+  .claude/skills/geo-loop/SKILL.md
+```
+
+## Key decisions
+
+### D1 — No new binary: `loop` is a subcommand group of `egeo`
+
+Upstream specified `egeo_loop.py run|collect|doctor`. v2.0 already has one
+entrypoint (`egeo` / `python -m egeo`), a dispatch table, and per-subcommand
+parser builders. Adding a second top-level script would fork the entrypoint,
+duplicate the mock-mode/`sys.path` bootstrap, and require another `py-modules`
+entry in `pyproject.toml`. Instead: `egeo/loop.py` implements
+`run|collect|doctor` and `egeo/cli.py` registers a single `loop` parser with a
+nested subparser. Command strings become `egeo loop run <domain>` etc.
+Consequence: no packaging change at all — the new module lives inside the
+already-declared `egeo` package.
+
+### D2 — The CLI is the trigger seam; the agent does the interpreting
+
+A loop run is interpretive work (data → knowledge), which lives in a markdown
+skill so it is reviewable and later improvable, not in Python. So
+`egeo loop run` deliberately does **not** call an LLM. It resolves and prints
+the run plan: the domain charter's current focus, collector deltas since the
+last Timeline entry, and candidate signals. `--dry-run` is the read-only
+contract test; without it the command additionally guarantees the workspace is
+bootstrapped and the domain exists, so the agent invocation that follows
+(`claude -p "/geo:loop <domain>"`) starts from a valid state. This keeps the
+LLM-free/LLM-bearing split identical to the collector/agent split.
+
+### D3 — Workspace-first prompt resolution instead of an unconditional redirect
+
+Upstream D-N2 said "`optimize()` writes to `$EGEO_HOME/prompts/` instead of the
+repo". Half of that hardening already shipped in v2.0: `--apply` gates the
+destructive write, and the default is a non-destructive `*.candidate.txt`. What
+remains, and what this change adds, is *state location*:
+
+1. `geo_eval` resolves each prompt file through the workspace first
+   (`$EGEO_HOME/prompts/<name>` wins over `prompts/<name>`), used by both
+   `evaluate` and `optimize`.
+2. When a bootstrapped workspace exists, `optimize` writes its result (applied
+   or candidate) into `$EGEO_HOME/prompts/`, leaving the repo tree pristine.
+3. When no workspace exists, resolution and write paths are exactly the v2.0
+   behavior. The change is purely additive for one-shot users.
+
+Rationale: a hard redirect would make `optimize` fail or silently create
+`~/.egeo` for users who never opted into loop mode. Gating on "workspace
+exists" makes loop mode opt-in while still guaranteeing that loop users never
+get their memory clobbered by `git pull`.
+
+### D4 — Collectors are stdlib scripts with a fixture mode
+
+Same style as `llm_client.py`: `urllib.request` for HTTP, `argparse`, JSON out.
+No `requests`, no `beautifulsoup4`; `page.py` parses HTML with
+`html.parser.HTMLParser`. Brave is called through its HTTP API rather than the
+Brave MCP because a cron-launched collector has no agent attached (upstream
+D-N3). Each collector exposes `main(argv)` so `egeo loop collect` can invoke it
+in-process, and `--fixture` replays recorded responses so CI covers the contract
+with no network and no key. Config is read from the workspace `config.yaml`
+through `egeo.workspace.load_config()`, which uses the already-declared `pyyaml`
+dependency when importable and a small inline parser for the documented config
+subset otherwise — so a bare-stdlib environment still runs collectors.
+
+### D5 — Substrate lint is vendored, not re-invented
+
+`egeo/substrate_lint.py` is an adaptation of loopstack's lint (stdlib only,
+`path:line: message`, non-zero exit). `egeo loop doctor` calls it as a library
+against the workspace root. This keeps a single mechanical definition of "valid
+artifact" on both sides of the vendoring boundary.
+
+### D6 — Budgets fail loud
+
+`config.yaml` carries `budgets.queries_per_day`. `serp.py` counts today's
+records already in its JSONL streams and refuses to exceed the cap, exiting
+non-zero with an actionable message rather than silently truncating — a
+collector that quietly stops collecting is worse than one that fails.
+
+## Risks / trade-offs
+
+- **Headless agent runs cost money and can flake.** Mitigated by one unit of
+  work per wake-up, `--dry-run`, and low cadence until the loop proves value.
+- **Two prompt locations can confuse users.** Mitigated by `doctor` printing
+  which prompts are overridden, and by "delete the workspace file to reset".
+- **Vendored-file drift.** The vendored `SUBSTRATE.md` carries its upstream
+  commit in a header comment, and `doctor` reports when the workspace copy
+  differs from the repo copy.
+- **Windows.** `Path.home()`, no symlinks, `\n` writes only.
+
+## Rollback
+
+Delete the new files and revert the `geo_eval.py`/`egeo/cli.py` diffs. Nothing
+in one-shot mode depends on them, and workspaces are user data: rollback leaves
+`$EGEO_HOME` untouched.

--- a/openspec/changes/add-geo-loop/proposal.md
+++ b/openspec/changes/add-geo-loop/proposal.md
@@ -1,0 +1,126 @@
+# Change: Add Loop Mode — Persistent Workspace, Collectors, and `egeo loop`
+
+## Why
+
+E-GEO is one-shot today. `/geo <url>` (or `egeo optimize <file>`) produces an
+audit plus `geo-output/` artifacts and is then forgotten. Three consequences:
+
+- **Nothing accumulates.** Every run starts from zero. There is no position
+  history, no record of which optimization was applied to which page, and no
+  way to answer "is this page doing better than last month?".
+- **Ranking validation is point-in-time and simulated.** `geo-ranker`
+  simulates an AI-engine ranking; without repeated ground-truth observations
+  the result cannot be corroborated, which is exactly why the repo already
+  labels uncorroborated output **Low Confidence**.
+- **There is no scheduler seam.** Nothing in the repo can be driven by cron.
+  Continuous optimization requires a plain CLI entrypoint any scheduler can
+  invoke.
+
+The design for this change was specified in the companion system repo
+(`mverab/loopstack`, change `phase-2-egeoagents-loop-integration`); this is the
+mirroring implementation change for eGEOagents v2.0.
+
+## What Changes
+
+### New: per-user workspace (loop state outside the repo)
+
+- Vendor `SUBSTRATE.md` (the knowledge-base contract) into the repo root.
+- Add `egeo/workspace.py`: single resolution of `$EGEO_HOME`
+  (default `~/.egeo/`) plus an **idempotent bootstrap** that creates
+  `LOG.md`, `config.yaml`, `signals/`, `docs/`, `data/`, `domains/`,
+  `prompts/`, copies `SUBSTRATE.md` into the workspace, and records the
+  bootstrap as one `LOG.md` line.
+- Add `egeo/substrate_lint.py` (stdlib only, adapted from loopstack's
+  `scripts/substrate_lint.py`) so the workspace can be linted mechanically.
+
+### New: deterministic collectors
+
+- `collectors/README.md` — the collector contract.
+- `collectors/serp.py` — Brave Search API over direct HTTPS (`BRAVE_API_KEY`,
+  stdlib `urllib`), queries from the workspace `config.yaml`; appends top-10
+  results plus the target's position to `data/serp/<query-slug>.jsonl`.
+- `collectors/page.py` — fetch configured URLs; append content hash, title,
+  meta description, JSON-LD `@type`s and word count to
+  `data/page/<page-slug>.jsonl`.
+- Both support a `--fixture` mode that replays recorded responses from disk, so
+  the contract is testable with no network and no API key.
+
+### New: `egeo loop` subcommands (existing CLI, no new binary)
+
+- `egeo loop run <domain> [--dry-run]` — resolve the run plan (charter focus,
+  fresh collector deltas since the last run, candidate signals). `--dry-run`
+  prints the plan and writes nothing. This is the trigger seam a scheduler
+  calls; the interpretive work itself is performed by the loop skill inside an
+  agent runtime.
+- `egeo loop collect <serp|page> [--fixture ...]` — one collector pass.
+- `egeo loop doctor` — workspace self-check (layout, config parse, substrate
+  lint, `BRAVE_API_KEY` presence as a warning, budget sanity).
+
+### New: the loop run procedure
+
+- `.claude/skills/geo-loop/SKILL.md` — read charter + fresh collector data +
+  recent signals → do **one** unit of work → write/update artifacts (signal
+  dedupe by `frequency`, docs cite sources) → append exactly one domain
+  `## Timeline` entry ending in `Outcome:` → append exactly one workspace
+  `LOG.md` line → verify both writes → exit.
+- `.claude/commands/geo-loop.md` — `/geo:loop [domain]` manual trigger.
+
+### Modified
+
+- `geo_eval.py` — **workspace-first prompt resolution**: when
+  `$EGEO_HOME/prompts/<name>.txt` exists it is preferred over the repo default,
+  for both `evaluate` and `optimize`. In loop mode (a bootstrapped workspace
+  exists) `optimize` writes its output prompt into `$EGEO_HOME/prompts/`
+  instead of the repo tree. With no workspace, behavior is byte-for-byte
+  unchanged.
+- `egeo/cli.py` — register the `loop` subcommand group.
+- `README.md`, `USAGE.md`, `.claude/CLAUDE.md`, `CHANGELOG.md` — document loop
+  mode, `$EGEO_HOME`, the collector contract, and Hermes cron examples.
+
+### Explicitly untouched
+
+`.claude/agents/`, existing `.claude/commands/geo*.md`, existing
+`.claude/skills/` (competitive-analysis, content-scoring, schema-generator,
+validation-doctor), `prompts/*.txt` defaults, `llm_client.py`,
+`egeo/agents.py`, `egeo/pipeline.py`, `egeo/runtimes.py`, and the
+`geo-output/` one-shot convention. One-shot `/geo` and `egeo optimize` keep
+working with no workspace present.
+
+## Impact
+
+### Affected specs
+
+- New capability: `geo-loop-runtime`.
+- New capability: `loop-collectors`.
+
+### Affected files (planned implementation)
+
+- `SUBSTRATE.md` (vendored), `egeo/workspace.py`, `egeo/substrate_lint.py`,
+  `egeo/loop.py` (new)
+- `egeo/cli.py`, `geo_eval.py` (modified)
+- `collectors/README.md`, `collectors/serp.py`, `collectors/page.py`,
+  `collectors/fixtures/*` (new)
+- `.claude/skills/geo-loop/SKILL.md`, `.claude/commands/geo-loop.md` (new)
+- `README.md`, `USAGE.md`, `.claude/CLAUDE.md`, `CHANGELOG.md` (docs)
+
+### External systems
+
+- Brave Search API (`BRAVE_API_KEY`) — direct HTTP, not MCP: collectors are
+  plain cron scripts with no agent attached. The Brave MCP remains the
+  interactive-session path.
+- A scheduler (Hermes cron is the reference) invoking the CLI.
+
+### Success criteria
+
+- `EGEO_HOME=$(mktemp -d) python -m egeo loop doctor` bootstraps a workspace and
+  reports it healthy; a second run changes nothing.
+- `python collectors/serp.py --fixture <recorded.json>` and
+  `python collectors/page.py --fixture <html-dir>` append schema-valid JSONL
+  with no network access, and re-running appends without corrupting prior lines.
+- `python -m egeo loop run <domain> --dry-run` prints a plan and modifies no
+  file in the workspace or the repo.
+- `GEO_EVAL_MOCK=1 python geo_eval.py evaluate --dataset eval/datasets/geo_smoke.jsonl --limit 5`
+  still passes, and `python scripts/validate_skills.py --root .` passes with the
+  new skill.
+- With `$EGEO_HOME/prompts/rewriter_user.txt` present it is the prompt actually
+  used; with no workspace the repo defaults are used exactly as before.

--- a/openspec/changes/add-geo-loop/specs/geo-loop-runtime/spec.md
+++ b/openspec/changes/add-geo-loop/specs/geo-loop-runtime/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Loop State Lives Outside the Repository
+All loop state — `LOG.md`, signals, docs, collector data, domain charters,
+optimized prompts, and configuration — SHALL live in the workspace resolved from
+`$EGEO_HOME` (default `~/.egeo/`). No loop run, collector pass, or prompt
+optimization SHALL write into the eGEOagents repository tree.
+
+#### Scenario: Updating the repo after months of loop runs
+- **WHEN** a user runs `git pull` in eGEOagents after accumulating loop state
+- **THEN** the update applies without touching the workspace
+- **AND** no workspace file is modified, overwritten, or lost
+
+#### Scenario: Prompt optimization keeps the repo pristine
+- **WHEN** `optimize` produces a prompt and a bootstrapped workspace exists
+- **THEN** the prompt is written under `$EGEO_HOME/prompts/`
+- **AND** the repo's `prompts/` directory is unchanged
+
+#### Scenario: Workspace prompts override repo defaults
+- **WHEN** `$EGEO_HOME/prompts/rewriter_user.txt` exists and `evaluate` runs
+- **THEN** the workspace file is the prompt actually used
+- **AND** deleting that file restores the repo default on the next run
+
+### Requirement: Workspace Bootstrap Is Idempotent
+The first invocation against a missing workspace SHALL create the `SUBSTRATE.md`
+layout (`LOG.md`, `signals/`, `docs/`, `data/`, `domains/`, `prompts/`), a
+`config.yaml` template carrying `cadence`, `models`, `budgets`,
+`reflect.auto_apply: never` and `scaling.weights`, a copy of `SUBSTRATE.md`, and
+exactly one bootstrap `LOG.md` line. Re-running bootstrap SHALL NOT overwrite any
+existing workspace file.
+
+#### Scenario: First run on a new machine
+- **WHEN** `egeo loop doctor` runs with no workspace present
+- **THEN** the workspace is created with the `SUBSTRATE.md` layout and a config template
+- **AND** the command reports the workspace healthy
+
+#### Scenario: Bootstrap re-run over existing state
+- **WHEN** bootstrap executes against a populated workspace
+- **THEN** every existing file is preserved byte-for-byte
+- **AND** no additional bootstrap `LOG.md` line is appended
+
+### Requirement: Loop Commands Are Subcommands of the `egeo` CLI
+Loop operations SHALL be exposed as `egeo loop run <domain> [--dry-run]`,
+`egeo loop collect <collector>`, and `egeo loop doctor`, runnable as `egeo` or
+`python -m egeo`. No separate loop binary SHALL be introduced.
+
+#### Scenario: Discovering the loop surface
+- **WHEN** a user runs `egeo loop --help`
+- **THEN** the `run`, `collect`, and `doctor` subcommands are listed with help text
+- **AND** the help states that the interpretive loop run itself is executed by the agent skill
+
+#### Scenario: Doctor reports workspace health
+- **WHEN** `egeo loop doctor` runs against a bootstrapped workspace
+- **THEN** it verifies the layout, parses `config.yaml`, lints workspace artifacts against the substrate contract, and checks budget sanity
+- **AND** a missing `BRAVE_API_KEY` is reported as a warning rather than a failure
+- **AND** secret values are never printed
+
+### Requirement: A Loop Run Is One Bounded Unit Of Work
+Each loop run SHALL perform at most one unit of work drawn from the domain's
+current focus or backlog, SHALL append exactly one domain `## Timeline` entry
+ending in an `Outcome:` line valued `success`, `partial`, `failure`, or `no-op`,
+SHALL append exactly one `LOG.md` line, and SHALL re-read both writes before
+exiting.
+
+#### Scenario: Normal loop run
+- **WHEN** `/geo:loop <domain>` completes
+- **THEN** exactly one new Timeline entry with an `Outcome:` class and one new `LOG.md` line exist
+- **AND** every written artifact passes the substrate checks
+
+#### Scenario: Dry run writes nothing
+- **WHEN** `egeo loop run <domain> --dry-run` is invoked
+- **THEN** the run plan — current focus, collector deltas since the last run, candidate signals — is printed
+- **AND** no file in the workspace or the repository is created or modified
+
+#### Scenario: Nothing worth doing
+- **WHEN** a loop run finds no fresh data and no actionable backlog item
+- **THEN** it records a Timeline entry with `Outcome: no-op` and one `LOG.md` line
+- **AND** it creates no signals or docs
+
+### Requirement: Triggers Are Scheduler-Agnostic And Delivery-Hygienic
+Loop runs and collector passes SHALL be triggerable by plain CLI invocation, so
+any scheduler (Hermes cron, system cron, manual, another agent) drives them
+identically. Documented scheduler examples SHALL pin provider and model per
+agent job, and jobs more frequent than weekly SHALL use local delivery plus a
+digest job summarizing `LOG.md`.
+
+#### Scenario: High-frequency collector job
+- **WHEN** a collector runs hourly under a scheduler
+- **THEN** its output is delivered locally as JSONL plus one `LOG.md` line
+- **AND** the owner is notified only through the periodic digest
+
+#### Scenario: Documented agent loop job
+- **WHEN** the documented cron example for an agent loop run is read
+- **THEN** it pins the provider and model for that job
+
+### Requirement: One-Shot Mode Is Preserved
+Existing one-shot behavior — `/geo` and the other `geo*` commands, the four
+agents, the existing skills, `egeo optimize`, `egeo evaluate`, and the
+`geo-output/` convention — SHALL remain unchanged and SHALL NOT require a
+workspace to exist.
+
+#### Scenario: User without a workspace optimizes a file
+- **WHEN** a user who never enabled loop mode runs `/geo <url>` or `egeo optimize <file>`
+- **THEN** the pipeline behaves exactly as it did before this change
+- **AND** no workspace directory is created
+
+#### Scenario: Offline gates stay green
+- **WHEN** the existing quality gates run with `GEO_EVAL_MOCK=1` and no workspace
+- **THEN** evaluation, skill validation, and JSON-LD validation all pass

--- a/openspec/changes/add-geo-loop/specs/loop-collectors/spec.md
+++ b/openspec/changes/add-geo-loop/specs/loop-collectors/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Collectors Are Deterministic And LLM-Free
+A collector SHALL be a deterministic script that makes zero LLM calls, reads its
+configuration from the workspace `config.yaml` and environment variables, and
+SHALL NOT write to `signals/`, `docs/`, or any other interpretive artifact.
+Collectors write data; agents write knowledge.
+
+#### Scenario: Collector attempts interpretation
+- **WHEN** review finds a collector writing to `signals/` or `docs/`, or calling an LLM endpoint
+- **THEN** the change is rejected against this requirement
+
+#### Scenario: Collector reads its configuration from the workspace
+- **WHEN** a collector pass starts
+- **THEN** its queries or URLs come from the workspace `config.yaml` and its credentials from the environment
+- **AND** no configuration is read from the repository tree
+
+### Requirement: Collector Output Is Append-Only Versioned JSONL
+Each collector pass SHALL append one JSON object per observation to
+`$EGEO_HOME/data/<collector>/<stream>.jsonl`, where every record carries a schema
+version field `v`, an ISO-8601 UTC `ts`, and a natural key sufficient for
+read-side deduplication. Existing lines SHALL never be modified or deleted.
+
+#### Scenario: Repeated pass on the same query
+- **WHEN** the SERP collector runs twice for the same query
+- **THEN** two records with distinct `ts` values exist in the stream
+- **AND** every previously written line is byte-identical
+
+#### Scenario: SERP record shape
+- **WHEN** the SERP collector records an observation
+- **THEN** the record contains `v`, `ts`, `query`, up to ten `results`, and `target_position` which is an integer or `null`
+
+#### Scenario: Page record shape
+- **WHEN** the page collector records an observation
+- **THEN** the record contains `v`, `ts`, `url`, `status`, `content_hash`, `title`, `meta_description`, `jsonld_types`, and `word_count`
+
+### Requirement: Collectors Fail Loudly And Log Once
+A collector pass SHALL exit non-zero on hard failure (authentication, network,
+schema, or budget) without writing partial records for the failed observation,
+and on success SHALL append exactly one `LOG.md` line summarizing the pass.
+
+#### Scenario: Brave API key missing
+- **WHEN** `collectors/serp.py` runs in network mode without `BRAVE_API_KEY`
+- **THEN** it exits non-zero with an actionable message
+- **AND** it appends no JSONL records and no `LOG.md` line
+
+#### Scenario: Daily query budget exceeded
+- **WHEN** a pass would exceed `budgets.queries_per_day` from `config.yaml`
+- **THEN** the collector exits non-zero naming the budget and the count
+- **AND** it does not silently reduce the query set
+
+#### Scenario: Successful pass logs one line
+- **WHEN** a collector pass completes successfully
+- **THEN** exactly one `LOG.md` line is appended, naming the collector and the number of observations, ending in an `outcome=` class
+
+### Requirement: Collectors Are Testable Without Network
+Every collector SHALL support a fixture mode that replays recorded responses
+from disk instead of performing network requests, and the contract SHALL be
+verifiable using fixtures only, with no API key present.
+
+#### Scenario: Fixture run with no network and no key
+- **WHEN** a collector runs with `--fixture <path>` in an environment without network access or `BRAVE_API_KEY`
+- **THEN** the pass succeeds and appends schema-valid JSONL records
+- **AND** no outbound request is attempted
+
+#### Scenario: Rate limiting in network mode
+- **WHEN** the SERP collector issues multiple queries against the live API
+- **THEN** it paces requests at no more than one query per second

--- a/openspec/changes/add-geo-loop/tasks.md
+++ b/openspec/changes/add-geo-loop/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Add Loop Mode — Workspace, Collectors, and `egeo loop`
+
+## 1. Contract
+
+- [x] 1.1 Scaffold `openspec/changes/add-geo-loop/` (proposal, design, tasks,
+      `specs/geo-loop-runtime/spec.md`, `specs/loop-collectors/spec.md`) and
+      pass `openspec validate add-geo-loop --strict`.
+- [x] 1.2 Vendor `SUBSTRATE.md` from loopstack into the repo root with a header
+      comment recording the upstream commit and vendoring date.
+
+## 2. Workspace
+
+- [x] 2.1 Add `egeo/workspace.py`: `resolve_home()` honoring `$EGEO_HOME` with a
+      `~/.egeo` default, plus `prompts_dir()`, `data_dir()`, `load_config()`,
+      `append_log()`.
+- [x] 2.2 Implement idempotent `bootstrap()`: create `LOG.md`, `config.yaml`
+      (cadence, models, budgets, `reflect.auto_apply: never`, scaling weights),
+      `signals/`, `docs/`, `data/`, `domains/`, `prompts/`; copy `SUBSTRATE.md`;
+      append the bootstrap `LOG.md` line. Never overwrite an existing file.
+- [x] 2.3 Add `egeo/substrate_lint.py` (stdlib only) adapted from loopstack's
+      `scripts/substrate_lint.py`, callable as a library.
+- [x] 2.4 Verify: `EGEO_HOME=$(mktemp -d) python -m egeo loop doctor` bootstraps
+      then reports healthy; a second run leaves every file byte-identical.
+
+## 3. Collectors
+
+- [x] 3.1 Write `collectors/README.md`: deterministic, zero LLM calls,
+      append-only versioned JSONL under `$EGEO_HOME/data/<collector>/`,
+      idempotent, no interpretation, one LOG line, non-zero exit on hard
+      failure.
+- [x] 3.2 Write `collectors/serp.py`: Brave Search API over stdlib `urllib`
+      (`BRAVE_API_KEY`), queries from `config.yaml`, records
+      `{v, ts, query, results[...], target_position}`; ≤1 qps; enforce
+      `budgets.queries_per_day`.
+- [x] 3.3 Write `collectors/page.py`: fetch configured URLs, record
+      `{v, ts, url, status, content_hash, title, meta_description,
+      jsonld_types, word_count}`.
+- [x] 3.4 Add `--fixture` mode to both collectors plus recorded fixtures under
+      `collectors/fixtures/`; verify both run offline and append valid JSONL
+      twice without corrupting earlier lines.
+
+## 4. Loop skill + command
+
+- [x] 4.1 Write `.claude/skills/geo-loop/SKILL.md`: read charter + fresh data +
+      recent signals, do ONE unit of work, write artifacts per `SUBSTRATE.md`,
+      append one Timeline entry ending in `Outcome:`, append one LOG line,
+      write-then-verify, exit.
+- [x] 4.2 Write `.claude/commands/geo-loop.md` (`/geo:loop [domain]`) following
+      the existing command-file conventions.
+- [x] 4.3 Verify `python scripts/validate_skills.py --root .` passes.
+
+## 5. CLI surface
+
+- [x] 5.1 Add `egeo/loop.py` with `run <domain> [--dry-run]`,
+      `collect <serp|page>`, `doctor`.
+- [x] 5.2 Register the `loop` subcommand group in `egeo/cli.py` following the
+      existing parser/dispatch pattern.
+- [x] 5.3 Add workspace-first prompt resolution to `geo_eval.py` and route
+      `optimize`'s output prompt into `$EGEO_HOME/prompts/` when a workspace
+      exists.
+- [x] 5.4 Verify: `python -m egeo loop run <domain> --dry-run` prints a plan and
+      writes nothing; `GEO_EVAL_MOCK=1` evaluate still passes; a workspace
+      `rewriter_user.txt` is the prompt actually used.
+
+## 6. Docs
+
+- [x] 6.1 Document loop mode, `$EGEO_HOME`, and the collector contract in
+      `README.md` and `USAGE.md`, including Hermes cron examples (pinned
+      provider+model, `deliver=local` + weekly digest).
+- [x] 6.2 Update `.claude/CLAUDE.md` with loop mode and state explicitly that
+      one-shot `/geo` and `egeo optimize` are unchanged.
+- [x] 6.3 Add a `CHANGELOG.md` `[Unreleased] > Added` entry.


### PR DESCRIPTION
## What

Adds **loop mode** to eGEOagents (v2.1 candidate): the one-shot `/geo` pipeline gains a continuous, self-logging loop over a per-user workspace at `$EGEO_HOME` (default `~/.egeo/`), with deterministic collectors for ground truth and a human-gated self-improvement path.

Design source: [mverab/loopstack](https://github.com/mverab/loopstack) (private) — phase-2 change adapted to eGEOagents v2.0.

## Deliverables

- **OpenSpec change** `openspec/changes/add-geo-loop/` (validates `--strict`)
- **Workspace**: `egeo/workspace.py` — `$EGEO_HOME` resolution + idempotent bootstrap (substrate layout, config, domains, LOG.md)
- **Collectors**: `collectors/serp.py` (Brave API direct, budget-capped, fixture mode) + `collectors/page.py` (content/schema drift) — stdlib-only, zero LLM calls
- **CLI**: `egeo loop run|collect|doctor` subcommands (`egeo/loop.py`); dry-run prints plan, writes nothing
- **Skill**: `.claude/skills/geo-loop/` + `/geo:loop` command — one bounded unit of work per run, write-then-verify, append-only history
- **D-N2**: workspace-first prompt resolution — `$EGEO_HOME/prompts/` overrides repo defaults when workspace exists; purely additive
- **Docs**: README, USAGE, CHANGELOG, CLAUDE.md — loop mode, collectors, Hermes cron examples

## Verified (Hermes, independently)

- `validate_skills.py`: 5/5 OK (incl. new geo-loop)
- `openspec validate add-geo-loop --strict`: valid
- Mock evaluate gate: green (`avg_rank_improvement: 2.0, win_rate: 1.0`)
- serp/page collectors: fixture JSONL valid, append-only, budget enforcement live (blocks when daily cap hit)
- doctor: bootstrap + idempotent second run
- dry-run: zero writes (sha256 of workspace identical before/after)
- workspace-first prompts: override log line confirmed, `git status prompts/` clean
- DO-NOT-TOUCH list (agents, existing commands/skills, prompts, llm_client, runtimes): 0 files modified

## Known gap

`/geo:loop` skill has not been executed end-to-end by a live Claude Code agent (no live session in build environment). Contract verified via dry-run plan + substrate lint. First real agent run happens in Phase 3 (PoC).

## Out of scope (later phases)

- Phase 3: slashstack.dev PoC workload (read-only diagnostic)
- Phase 4: reflect loop (outcomes → learnings → skill-proposals → human review)
- Phase 5: self-scaling backlog prioritization + vendorable template
- D-N5 housekeeping: validation-doctor dir/file duplication (separate commit)