### PR TITLE
chore: PyPI publish (OIDC) + site URLs + FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [mverab]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build
+        run: python -m pip install build twine
+      - name: Build and check
+        run: |
+          python -m build
+          python -m twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+
+  publish:
+    name: Upload to PyPI (trusted publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/egeo
+    permissions:
+      id-token: write  # OIDC trusted publishing — no API token stored
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
 egeo = "egeo.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/mverab/eGEOagents"
+Homepage = "https://egeoagents.com"
 Repository = "https://github.com/mverab/eGEOagents"
-Documentation = "https://github.com/mverab/eGEOagents#readme"
+Documentation = "https://egeoagents.com/docs/getting-started/"
 
 [tool.setuptools]
 # The CLI package plus the root-level harness modules it reuses. Declaring the


### PR DESCRIPTION
- `publish-pypi.yml`: builds sdist+wheel on every GitHub Release, publishes via **trusted publishing (OIDC)** — no API token stored anywhere. Requires one-time PyPI setup: create pending publisher for repo `mverab/eGEOagents`, workflow `publish-pypi.yml`, environment `pypi`.
- `pyproject.toml`: Homepage → https://egeoagents.com, Documentation → https://egeoagents.com/docs/getting-started/ (entity consistency across surfaces).
- `FUNDING.yml`: `github: [mverab]` (Sponsor button activates when the Sponsors account is approved).
- Verified locally: `python -m build` + `twine check` PASSED (egeo 2.0.0).