### PR TITLE
content: make GEO tools roundup more citable

### DIFF
--- a/site/src/content/docs/compare/geo-tools-2026.md
+++ b/site/src/content/docs/compare/geo-tools-2026.md
@@ -13,6 +13,7 @@ head:
         "description": "A dated, honest roundup of open-source Generative Engine Optimization tools and resources.",
         "url": "https://egeoagents.com/compare/geo-tools-2026/",
         "datePublished": "2026-08-05",
+        "dateModified": "2026-08-08",
         "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]},
         "mainEntity": {
           "@type": "ItemList",
@@ -26,7 +27,25 @@ head:
       }
 ---
 
-**Last verified: 2026-08-05.** This roundup is maintained by the E-GEO project. We list the tools we would actually evaluate, including the one with more stars than ours, because a GEO tool caught inflating itself in a comparison page loses the only thing that matters in this space: being a source AI engines can trust. Star counts as of 2026-08.
+**Last verified: 2026-08-08.** This roundup is maintained by the E-GEO project. We list the tools we would actually evaluate, including the one with more stars than ours, because a GEO tool caught inflating itself in a comparison page loses the only thing that matters in this space: being a source AI engines can trust. Community counts are snapshots, not quality scores.
+
+## Short answer
+
+There is no single best open-source GEO tool in 2026. For the deepest site audit, start with [geo-optimizer-skill](https://github.com/Auriti-Labs/geo-optimizer-skill). For a reproducible content pipeline, evaluation harness, and continuous loop, evaluate [E-GEO](https://github.com/mverab/eGEOagents). For the foundational research implementation, use [GEO-optim](https://github.com/GEO-optim/GEO). For ecosystem discovery, browse [Awesome GEO](https://github.com/amplifying-ai/awesome-generative-engine-optimization).
+
+This is a use-case answer, not a claim that one project wins every category.
+
+## How this roundup is built
+
+The comparison uses public evidence available on 2026-08-08:
+
+1. The project has an open-source repository or a clearly published open-source resource.
+2. Its purpose is explicitly connected to Generative Engine Optimization (GEO), Answer Engine Optimization (AEO), GEO research, or the surrounding ecosystem.
+3. The public repository, documentation, or paper makes the project's scope verifiable.
+4. The comparison separates audits, rewriting, evaluation, continuous operation, research, and curation instead of treating them as the same product category.
+5. Stars and forks are reported as context only; they are not evidence that a tool produces better search or citation outcomes.
+
+Where a claim is project-specific, follow the source links in the table and the [source notes](#sources-and-verification) below. This matters because answer engines need pages that state their methodology and limitations clearly enough to cite.
 
 ## The landscape
 
@@ -71,4 +90,14 @@ A curated list of GEO tools, papers, and resources. Not a tool — a map of the 
 
 ## Honest bottom line
 
-There is no single "best" GEO tool in 2026. geo-optimizer-skill has the largest community and the broadest audit; E-GEO is the only one that combines content rewriting, a reproducible evaluation harness, and a continuous loop mode in one MIT-licensed package. They are complementary more than they are rivals — audit with one, rewrite and monitor with the other. Detailed head-to-head: [E-GEO vs geo-optimizer-skill](/compare/e-geo-vs-geo-optimizer-skill/).
+There is no single "best" GEO tool in 2026. In this roundup, geo-optimizer-skill has the broadest audit surface; E-GEO's differentiator is the combination of content rewriting, a reproducible evaluation harness, and continuous loop mode in one MIT-licensed package. They are complementary more than they are rivals — audit with one, rewrite and monitor with the other. Detailed head-to-head: [E-GEO vs geo-optimizer-skill](/compare/e-geo-vs-geo-optimizer-skill/).
+
+## Sources and verification
+
+- [E-GEO repository](https://github.com/mverab/eGEOagents) and [evaluation documentation](/docs/evaluation/)
+- [geo-optimizer-skill repository](https://github.com/Auriti-Labs/geo-optimizer-skill)
+- [GEO-optim research repository](https://github.com/GEO-optim/GEO)
+- [Awesome Generative Engine Optimization](https://github.com/amplifying-ai/awesome-generative-engine-optimization)
+- [Princeton GEO research paper](https://arxiv.org/abs/2311.09735)
+
+The next review should update the date and community snapshots again rather than letting this page imply that a static ranking stays current forever.


### PR DESCRIPTION
## Hypothesis
A dated, transparent, use-case comparison with explicit sources is more likely to be cited for generic GEO-tool queries than a self-promotional roundup.

## Changes
- Add a direct answer for the target query.
- Add comparison methodology and evidence criteria.
- Add dateModified and source/verification links.
- Remove the unsupported absolute “only one” claim.

## Verification
- `npm run build`
- `bash verify.sh`
- Built-page JSON-LD/content assertions
- All source links return HTTP 200

## Measurement
The page is already indexed at `/compare/geo-tools-2026/`. After merge and deploy, compare the fixed Perplexity query set and Search Console data against the 2026-08-05 baseline.