### PR TITLE
docs: clarify research and MCP client claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@
 
 Also known as **AI SEO** or **LLM SEO**, GEO is the practice of optimizing content so that generative AI engines can crawl, understand, cite, and recommend it. E-GEO automates this entire process.
 
-Based on the [E-GEO research paper](https://arxiv.org/abs/2511.20867) (arXiv:2511.20867), it applies the **10 universal features** that consistently improve AI-engine rankings — competitive framing, citation optimization, structured data, and semantic density improvements backed by peer-reviewed findings.
+Based on the [E-GEO research preprint](https://arxiv.org/abs/2511.20867) (arXiv:2511.20867), it applies **10 research-derived features** — including competitive framing, citation optimization, structured data, and semantic density improvements — as documented in the paper's experiments.
 
 - ✅ **No learning curve** — One command to optimize
-- ✅ **Research-backed** — Based on peer-reviewed findings
+- ✅ **Research-backed** — Based on published GEO research
 - ✅ **Production-ready** — Copy-paste optimized content
 - ✅ **Multi-engine** — Optimizes for ChatGPT, Perplexity, Gemini, Claude & Google AI Overviews
 - ✅ **Full pipeline** — Analyze → Rank → Rewrite → Schema in one command
@@ -193,7 +193,7 @@ geo-output/
 
 ## 🎯 Results: Backed by Research
 
-E-GEO is grounded in peer-reviewed research from the [E-GEO research paper](https://arxiv.org/abs/2511.20867) (arXiv:2511.20867), building on foundational work by [Aggarwal et al. (Princeton, KDD 2024)](https://arxiv.org/abs/2311.09735) — the original study that defined Generative Engine Optimization as a discipline.
+E-GEO is grounded in the research described in the [E-GEO preprint](https://arxiv.org/abs/2511.20867) (arXiv:2511.20867), building on foundational work by [Aggarwal et al. (Princeton, KDD 2024)](https://arxiv.org/abs/2311.09735) — the original study that defined Generative Engine Optimization as a discipline.
 
 The E-GEO paper reports that:
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -9,7 +9,7 @@ E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered
 - [Getting Started](https://egeoagents.com/docs/getting-started/): install the CLI or Claude Code skills and run a first optimization
 - [How It Works](https://egeoagents.com/docs/how-it-works/): the 4-agent pipeline, the 10 GEO features, and the research behind them
 - [CLI Reference](https://egeoagents.com/docs/cli/): egeo optimize, evaluate, optimize-prompts, runtimes, loop
-- [MCP Server](https://egeoagents.com/docs/mcp-server/): MCP-based validation layer (Brave Search, Chrome DevTools)
+- [MCP-based validation](https://egeoagents.com/docs/mcp-server/): E-GEO's Claude Code workflow consumes external MCP servers for Brave Search and Chrome DevTools validation
 - [GEO Loop](https://egeoagents.com/docs/geo-loop/): continuous GEO with deterministic collectors and $EGEO_HOME
 - [Evaluation Harness](https://egeoagents.com/docs/evaluation/): reproducible metrics, dataset format, honest limitations
 - [FAQ](https://egeoagents.com/docs/faq/): differences from geo-optimizer-skill, Claude Code and API key requirements

--- a/site/src/content/docs/docs/how-it-works.md
+++ b/site/src/content/docs/docs/how-it-works.md
@@ -96,7 +96,7 @@ See the paper for full methodology; results vary by content quality and competit
 
 ## Validation layer
 
-When run through Claude Code, E-GEO validates outputs against ground truth using MCP servers:
+When run through Claude Code, E-GEO's client workflow validates outputs against ground truth using external MCP servers:
 
 | MCP server | Purpose | Criticality |
 |------------|---------|-------------|
@@ -104,7 +104,7 @@ When run through Claude Code, E-GEO validates outputs against ground truth using
 | **Chrome DevTools** | Rendered DOM validation, performance metrics | High |
 | **fetch** | Simple text scraping (fallback) | Medium |
 
-When MCP servers are unavailable, E-GEO still runs but marks outputs **"Low Confidence"**. See [MCP Server](/docs/mcp-server/) for setup.
+When MCP servers are unavailable, E-GEO still runs but marks outputs **"Low Confidence"**. See [MCP-based validation](/docs/mcp-server/) for setup.
 
 ## Auto-triggered skills
 

--- a/site/src/content/docs/docs/mcp-server.md
+++ b/site/src/content/docs/docs/mcp-server.md
@@ -1,6 +1,6 @@
 ---
-title: MCP Server
-description: How E-GEO uses MCP servers for validation — Brave Search for competitor ground truth and Chrome DevTools for rendered-DOM checks.
+title: MCP-Based Validation
+description: How E-GEO's Claude Code workflow consumes external MCP servers for validation — Brave Search for competitor ground truth and Chrome DevTools for rendered-DOM checks.
 head:
   - tag: script
     attrs:
@@ -9,18 +9,18 @@ head:
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "headline": "E-GEO and MCP Servers",
-        "description": "How E-GEO uses MCP servers for validation: Brave Search for competitor ground truth and Chrome DevTools for rendered-DOM checks.",
+        "headline": "E-GEO and MCP-Based Validation",
+        "description": "How E-GEO's Claude Code workflow consumes external MCP servers for validation: Brave Search for competitor ground truth and Chrome DevTools for rendered-DOM checks.",
         "url": "https://egeoagents.com/docs/mcp-server/",
         "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]}
       }
 ---
 
-E-GEO integrates with the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) to ground its analysis in real data instead of model guesses. When running through Claude Code, the pipeline uses MCP servers as its validation layer.
+E-GEO integrates with the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) as a client-side validation workflow. When running through Claude Code, E-GEO consumes external MCP servers as its validation layer; E-GEO is not itself an MCP server.
 
 ## Why MCP matters for GEO
 
-A GEO tool that claims competitor rankings without checking real search results is guessing. E-GEO's rule: **do not claim competitor rankings without search ground truth.** MCP servers provide that ground truth.
+A GEO tool that claims competitor rankings without checking real search results is guessing. E-GEO's rule: **do not claim competitor rankings without search ground truth.** The configured external MCP servers provide that ground truth.
 
 ## Required servers for fully validated results
 


### PR DESCRIPTION
## Summary
- Replace peer-review wording for arXiv:2511.20867 with accurate preprint/published-research wording.
- Clarify that E-GEO consumes external MCP servers as a client-side validation workflow.
- Preserve the existing `/docs/mcp-server/` URL while improving title, metadata, `llms.txt`, and cross-links.

## Verification
- README contains no peer-review claim for the E-GEO preprint.
- `npm run build`
- `bash verify.sh`
- Built MCP page assertions for title, JSON-LD, and client statement.