### PR TITLE
feat(collectors): add SerpBase (Google) SERP engine option to serp.py

### DIFF
--- a/collectors/README.md
+++ b/collectors/README.md
@@ -43,7 +43,7 @@ A collector in this directory MUST:
 | `serp.py` | `data/serp/<query-slug>.jsonl` | `{v, ts, query, engine, results[≤10], target_domain, target_position}` |
 | `page.py` | `data/page/<page-slug>.jsonl` | `{v, ts, url, status, content_hash, title, meta_description, jsonld_types, word_count}` |
 
-### `serp.py` — position history from the Brave Search API
+### `serp.py` — position history from the Brave Search API or the SerpBase Google Search API
 
 ```bash
 export BRAVE_API_KEY=...                  # never printed, never written to disk
@@ -51,10 +51,15 @@ python collectors/serp.py                 # all queries from config.yaml
 python collectors/serp.py --query "best geo tool"
 python collectors/serp.py --fixture collectors/fixtures/serp_brave_response.json
 python -m egeo loop collect serp          # equivalent, in-process
+
+# Google SERP instead of Brave: SerpBase Google Search API (organic + AI Overviews)
+export SERPBASE_API_KEY=...
+python collectors/serp.py --engine serpbase
+python collectors/serp.py --engine serpbase --fixture collectors/fixtures/serp_serpbase_response.json
 ```
 
-Brave is called over its **HTTP API directly**, not through the Brave MCP:
-collectors run under cron with no agent attached, so an MCP server is not
+Brave and SerpBase are called over their **HTTP APIs directly**, not through an
+MCP: collectors run under cron with no agent attached, so an MCP server is not
 available to them. The MCP stays the path for interactive agent sessions. Live
 passes are paced at ≤1 query/second and refuse to exceed
 `budgets.queries_per_day`.
@@ -64,6 +69,7 @@ Config:
 ```yaml
 collectors:
   serp:
+    engine: brave          # optional: brave (default) or serpbase (Google via SerpBase)
     target_domain: example.com     # position is reported for this domain
     queries:
       - best geo optimization tool
@@ -100,9 +106,10 @@ collectors:
 ## Fixtures
 
 `fixtures/serp_brave_response.json` is a recorded Brave `/res/v1/web/search`
-response body; `fixtures/pages/*.html` are recorded page bodies whose file names
-encode the URL slug. Fixture mode is what CI runs: no network, no key, same code
-path, same schema.
+response body; `fixtures/serp_serpbase_response.json` is a recorded SerpBase
+`POST /google/search` response body; `fixtures/pages/*.html` are recorded page
+bodies whose file names encode the URL slug. Fixture mode is what CI runs: no
+network, no key, same code path, same schema.
 
 ## Adding a collector
 

--- a/collectors/_common.py
+++ b/collectors/_common.py
@@ -97,6 +97,39 @@ def http_get(url: str, headers: Optional[Dict[str, str]] = None, timeout: int = 
         raise CollectorError(f"network failure for {url}: {exc}") from exc
 
 
+def http_post(
+    url: str,
+    payload: Dict[str, Any],
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 30,
+):
+    """POST a JSON body with stdlib urllib. Returns ``(status, body_text)``.
+
+    Same contract as :func:`http_get`: transport failures raise
+    :class:`CollectorError`; HTTP error responses are returned with their
+    status so the caller decides whether they are fatal. Used by collectors
+    whose upstream is a POST JSON API (e.g. ``serp.py`` with the SerpBase
+    Google Search API).
+    """
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={"User-Agent": USER_AGENT, "Content-Type": "application/json", **(headers or {})},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            return response.status, response.read().decode(charset, errors="replace")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        return exc.code, body
+    except urllib.error.URLError as exc:
+        raise CollectorError(f"network failure for {url}: {exc.reason}") from exc
+    except OSError as exc:  # timeouts, DNS, TLS
+        raise CollectorError(f"network failure for {url}: {exc}") from exc
+
+
 def ensure_workspace(home: Optional[Path] = None) -> Path:
     """Resolve and bootstrap the workspace, returning its path."""
     resolved = home or workspace.resolve_home()

--- a/collectors/fixtures/serp_serpbase_response.json
+++ b/collectors/fixtures/serp_serpbase_response.json
@@ -1,0 +1,103 @@
+{
+  "_fixture": "Recorded shape of a SerpBase POST /google/search response body, trimmed to the fields collectors/serp.py reads. Synthetic content, real schema: used by offline contract tests (python collectors/serp.py --engine serpbase --fixture ...).",
+  "status": 0,
+  "request_id": "req_fixture_serpbase_0001",
+  "elapsed_ms": 412,
+  "credits_charged": 1,
+  "search_type": "search",
+  "query": "best geo optimization tool",
+  "page": 1,
+  "organic": [
+    {
+      "rank": 1,
+      "position": 1,
+      "title": "The 12 Best GEO Tools (2026 Review)",
+      "link": "https://searchmonitor.example/blog/best-geo-tools",
+      "url": "https://searchmonitor.example/blog/best-geo-tools",
+      "display_link": "searchmonitor.example",
+      "snippet": "Ranked roundup of generative engine optimization tools."
+    },
+    {
+      "rank": 2,
+      "position": 2,
+      "title": "GEO Optimization Platform",
+      "link": "https://www.rivalgeo.example/platform",
+      "url": "https://www.rivalgeo.example/platform",
+      "display_link": "www.rivalgeo.example",
+      "snippet": "Enterprise GEO suite."
+    },
+    {
+      "rank": 3,
+      "position": 3,
+      "title": "E-GEO: open-source generative engine optimization",
+      "link": "https://example.com/egeo",
+      "url": "https://example.com/egeo",
+      "display_link": "example.com",
+      "snippet": "Zero-effort GEO for AI search engines."
+    },
+    {
+      "rank": 4,
+      "position": 4,
+      "title": "How AI search engines pick sources",
+      "link": "https://airesearch.example/papers/geo",
+      "url": "https://airesearch.example/papers/geo",
+      "snippet": "Study of citation behavior."
+    },
+    {
+      "rank": 5,
+      "position": 5,
+      "title": "GEO vs SEO explained",
+      "link": "https://contentlab.example/geo-vs-seo",
+      "url": "https://contentlab.example/geo-vs-seo",
+      "snippet": "Primer on the differences."
+    },
+    {
+      "rank": 6,
+      "position": 6,
+      "title": "Best AI visibility trackers",
+      "link": "https://toolsdigest.example/ai-visibility",
+      "url": "https://toolsdigest.example/ai-visibility",
+      "snippet": "Comparison table."
+    },
+    {
+      "rank": 7,
+      "position": 7,
+      "title": "Optimizing content for ChatGPT answers",
+      "link": "https://promptcraft.example/chatgpt-visibility",
+      "url": "https://promptcraft.example/chatgpt-visibility",
+      "snippet": "Tactics and pitfalls."
+    },
+    {
+      "rank": 8,
+      "position": 8,
+      "title": "Schema markup for AI answers",
+      "link": "https://schemaguide.example/ai",
+      "url": "https://schemaguide.example/ai",
+      "snippet": "JSON-LD patterns."
+    },
+    {
+      "rank": 9,
+      "position": 9,
+      "title": "Perplexity ranking factors",
+      "link": "https://serpnotes.example/perplexity",
+      "url": "https://serpnotes.example/perplexity",
+      "snippet": "Observed factors."
+    },
+    {
+      "rank": 10,
+      "position": 10,
+      "title": "GEO checklist",
+      "link": "https://growthwiki.example/geo-checklist",
+      "url": "https://growthwiki.example/geo-checklist",
+      "snippet": "Implementation checklist."
+    },
+    {
+      "rank": 11,
+      "position": 11,
+      "title": "Overflow result (must be dropped at 10)",
+      "link": "https://ignored.example/eleventh",
+      "url": "https://ignored.example/eleventh",
+      "snippet": "Beyond top-10."
+    }
+  ]
+}

--- a/collectors/serp.py
+++ b/collectors/serp.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""SERP collector: position history for your queries, from the Brave Search API.
+"""SERP collector: position history for your queries, from the Brave Search API
+or the SerpBase Google Search API.
 
 Deterministic, zero LLM calls. One record per query per pass, appended to
 ``$EGEO_HOME/data/serp/<query-slug>.jsonl``::
@@ -8,16 +9,25 @@ Deterministic, zero LLM calls. One record per query per pass, appended to
      "results": [{"position": 1, "url": "...", "domain": "...", "title": "..."}, ...],
      "target_domain": "example.com", "target_position": 3 | null}
 
-Brave is called over its HTTP API directly (``BRAVE_API_KEY``) rather than
-through the Brave MCP: a cron-launched collector has no agent, hence no MCP.
-Live passes are paced at ≤1 query/second and refuse to exceed
-``budgets.queries_per_day``.
+The engine is selected with ``--engine brave|serpbase`` (or
+``collectors.serp.engine`` in config.yaml; default ``brave``):
+
+- ``brave`` — Brave Search API over HTTP directly (``BRAVE_API_KEY``).
+- ``serpbase`` — SerpBase Google Search API (``SERPBASE_API_KEY``): Google
+  organic results (plus AI Overviews on the SERP) as JSON, no browser.
+
+Both are called over their HTTP API directly (``BRAVE_API_KEY`` /
+``SERPBASE_API_KEY``) rather than through an MCP: a cron-launched collector
+has no agent, hence no MCP. Live passes are paced at ≤1 query/second and
+refuse to exceed ``budgets.queries_per_day``.
 
 Usage::
 
     python collectors/serp.py                       # queries from config.yaml
     python collectors/serp.py --query "best geo tool"
+    python collectors/serp.py --engine serpbase     # Google SERP via SerpBase
     python collectors/serp.py --fixture collectors/fixtures/serp_brave_response.json
+    python collectors/serp.py --engine serpbase --fixture collectors/fixtures/serp_serpbase_response.json
 """
 from __future__ import annotations
 
@@ -42,6 +52,9 @@ COLLECTOR = "serp"
 ENGINE = "brave"
 API_URL = "https://api.search.brave.com/res/v1/web/search"
 API_KEY_ENV = "BRAVE_API_KEY"
+SERPBASE_ENGINE = "serpbase"
+SERPBASE_API_URL = "https://api.serpbase.dev/google/search"
+SERPBASE_API_KEY_ENV = "SERPBASE_API_KEY"
 MAX_RESULTS = 10
 MIN_SECONDS_BETWEEN_QUERIES = 1.0
 
@@ -102,6 +115,55 @@ def parse_brave_response(payload: Dict[str, Any], query: str, target_domain: str
     }
 
 
+def parse_serpbase_response(payload: Dict[str, Any], query: str, target_domain: str) -> Dict[str, Any]:
+    """Turn a SerpBase ``/google/search`` body into one versioned observation record.
+
+    Same contract as :func:`parse_brave_response`: positions are the rank
+    Google returned (``rank``; ``position`` is the normalized alias), the
+    target position is the first result whose domain matches, or ``None``.
+    """
+    if payload.get("status") != 0:
+        raise common.CollectorError(
+            f"SerpBase API reported status {payload.get('status')!r} for {query!r} "
+            f"(request_id={payload.get('request_id')!r})"
+        )
+    raw_results = payload.get("organic") or []
+    if not isinstance(raw_results, list):
+        raise common.CollectorError(f"unexpected SerpBase payload for {query!r}: organic is not a list")
+
+    results: List[Dict[str, Any]] = []
+    for index, item in enumerate(raw_results[:MAX_RESULTS], start=1):
+        if not isinstance(item, dict):
+            raise common.CollectorError(f"unexpected SerpBase payload for {query!r}: result is not an object")
+        url = str(item.get("link") or item.get("url") or "")
+        results.append(
+            {
+                "position": int(item.get("rank") or index),
+                "url": url,
+                "domain": _domain_of(url),
+                "title": str(item.get("title", "")),
+            }
+        )
+
+    target = _normalize_domain(target_domain)
+    target_position = None
+    if target:
+        for result in results:
+            if result["domain"] == target or result["domain"].endswith("." + target):
+                target_position = result["position"]
+                break
+
+    return {
+        "v": SCHEMA_VERSION,
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query": query,
+        "engine": SERPBASE_ENGINE,
+        "results": results,
+        "target_domain": target or None,
+        "target_position": target_position,
+    }
+
+
 def fetch_brave(query: str, api_key: str, count: int = MAX_RESULTS) -> Dict[str, Any]:
     """Call the Brave Search API and return the parsed JSON body."""
     url = f"{API_URL}?{urlencode({'q': query, 'count': count})}"
@@ -126,6 +188,35 @@ def fetch_brave(query: str, api_key: str, count: int = MAX_RESULTS) -> Dict[str,
     return payload
 
 
+def fetch_serpbase(query: str, api_key: str, count: int = MAX_RESULTS) -> Dict[str, Any]:
+    """Call the SerpBase Google Search API and return the parsed JSON body.
+
+    SerpBase is a POST JSON API (``X-API-Key`` header); the response envelope
+    is ``{"status": 0, "request_id": "...", "organic": [...]}``.
+    """
+    url = SERPBASE_API_URL
+    status, body = common.http_post(
+        url,
+        headers={"Content-Type": "application/json", "X-API-Key": api_key},
+        payload={"q": query, "hl": "en", "gl": "us", "device": "default"},
+    )
+    if status == 401 or status == 403:
+        raise common.CollectorError(
+            f"SerpBase API rejected the request (HTTP {status}). Check ${SERPBASE_API_KEY_ENV}."
+        )
+    if status == 429:
+        raise common.CollectorError("SerpBase API rate limit hit (HTTP 429); retry later or lower the cadence.")
+    if status != 200:
+        raise common.CollectorError(f"SerpBase API returned HTTP {status} for {query!r}")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise common.CollectorError(f"SerpBase API returned invalid JSON for {query!r}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise common.CollectorError(f"SerpBase API returned a non-object body for {query!r}")
+    return payload
+
+
 def load_fixture(path: Path) -> Dict[str, Any]:
     """Read a recorded Brave response body from disk (fixture mode)."""
     try:
@@ -146,6 +237,7 @@ def collect(
     home: Path,
     fixture: Optional[Path] = None,
     budget: Optional[int] = None,
+    engine: str = ENGINE,
 ) -> Dict[str, Any]:
     """Run one pass over ``queries``. Returns a machine-readable summary."""
     if not queries:
@@ -153,11 +245,14 @@ def collect(
             "no queries configured: add collectors.serp.queries to "
             f"{home / workspace.CONFIG_NAME} or pass --query"
         )
+    if engine not in (ENGINE, SERPBASE_ENGINE):
+        raise common.CollectorError(f"unknown SERP engine {engine!r}: choose from '{ENGINE}', '{SERPBASE_ENGINE}'")
 
-    api_key = os.environ.get(API_KEY_ENV, "").strip()
+    key_env = API_KEY_ENV if engine == ENGINE else SERPBASE_API_KEY_ENV
+    api_key = os.environ.get(key_env, "").strip()
     if fixture is None and not api_key:
         raise common.CollectorError(
-            f"${API_KEY_ENV} is not set. Export a Brave Search API key, or run with "
+            f"${key_env} is not set. Export a {engine} API key, or run with "
             "--fixture <recorded-response.json> for an offline pass."
         )
 
@@ -180,8 +275,14 @@ def collect(
         else:
             if index:
                 time.sleep(MIN_SECONDS_BETWEEN_QUERIES)
-            payload = fetch_brave(query, api_key)
-        record = parse_brave_response(payload, query, target_domain)
+            if engine == SERPBASE_ENGINE:
+                payload = fetch_serpbase(query, api_key)
+            else:
+                payload = fetch_brave(query, api_key)
+        if engine == SERPBASE_ENGINE:
+            record = parse_serpbase_response(payload, query, target_domain)
+        else:
+            record = parse_brave_response(payload, query, target_domain)
         common.append_record(paths[query], record)
         written.append({"query": query, "stream": str(paths[query]), "target_position": record["target_position"]})
 
@@ -209,9 +310,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Domain to report a position for. Default: collectors.serp.target_domain.",
     )
     parser.add_argument(
+        "--engine",
+        choices=[ENGINE, SERPBASE_ENGINE],
+        default=None,
+        help=f"SERP source engine: '{ENGINE}' (Brave Search API) or '{SERPBASE_ENGINE}' "
+        f"(SerpBase Google Search API). Default: collectors.serp.engine from config.yaml, else '{ENGINE}'.",
+    )
+    parser.add_argument(
         "--fixture",
         default=None,
-        help="Replay a recorded Brave response JSON file instead of calling the API (offline).",
+        help="Replay a recorded response JSON file instead of calling the API (offline). "
+        "Use --engine serpbase with collectors/fixtures/serp_serpbase_response.json for a Google SERP pass.",
     )
     parser.add_argument("--json", action="store_true", help="Print the machine-readable summary.")
     return parser
@@ -229,6 +338,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     target_domain = args.target_domain or str(
         workspace.config_get(config, "collectors.serp.target_domain", "") or ""
     )
+    engine = args.engine or str(workspace.config_get(config, "collectors.serp.engine", ENGINE) or ENGINE)
     budget = workspace.config_get(config, "budgets.queries_per_day", None)
 
     try:
@@ -238,6 +348,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             home=home,
             fixture=Path(args.fixture).expanduser() if args.fixture else None,
             budget=int(budget) if budget else None,
+            engine=engine,
         )
     except common.CollectorError as exc:
         return common.fail(str(exc))


### PR DESCRIPTION
## Summary

Adds an opt-in `--engine serpbase` option to `collectors/serp.py`, giving loop mode a Google SERP source alongside the existing Brave one. Brave remains the default; nothing changes for existing workspaces.

## Background

`collectors/serp.py` currently records position history exclusively from the Brave Search API. E-GEO's targets include Google AI Overviews, but Brave's index is not Google's — positions recorded from Brave can differ from what a Google AI Overview actually cites. SerpBase (https://serpbase.dev) returns Google organic results (and AI Overview content when the SERP has it) as JSON over a simple REST call, so the collector can observe the Google SERP the GEO loop is trying to influence, without a browser.

## Changes

- **`collectors/_common.py`** — new `http_post()` helper (stdlib urllib, same error contract as `http_get`) for POST JSON APIs.
- **`collectors/serp.py`** — `SERPBASE_API_URL` / `SERPBASE_API_KEY_ENV` constants, `fetch_serpbase()`, `parse_serpbase_response()`, `--engine {brave,serpbase}` CLI flag, and `collectors.serp.engine` config key (default `brave`). Records carry `engine: "serpbase"` and use the same `{v, ts, query, engine, results[≤10], target_domain, target_position}` schema.
- **`collectors/fixtures/serp_serpbase_response.json`** — new recorded-shape fixture so the SerpBase path is testable offline (same pattern as the Brave fixture; includes an 11th result to prove the ≤10 truncation).
- **`collectors/README.md`** — documents the engine flag, config key, and fixture.

## Design decisions

| Decision | Rationale |
|---|---|
| POST JSON + `X-API-Key` header | SerpBase's current API contract (verified against serpbase.dev docs) |
| Opt-in flag, `brave` default | No behavior change for existing users/workspaces |
| Missing `SERPBASE_API_KEY` fails loudly | Same contract as `BRAVE_API_KEY` (collectors/README.md point 8: fail loudly) |
| Stdlib only (`http_post` in `_common.py`) | No new dependencies — respects the "no `requests`/`bs4` anywhere in loop mode" rule |
| Fixture mode | Same code path, no network, no key — matches how the Brave path is tested |

## Testing

- `python collectors/serp.py --engine serpbase --fixture collectors/fixtures/serp_serpbase_response.json --query "best geo optimization tool" --target-domain example.com --json` → record with `engine: "serpbase"`, 10 results (11th truncated), `target_position: 3`.
- Existing Brave fixture pass unchanged (regression).
- Missing key without `--fixture` → clear error, exit 1.
- `python -m py_compile` clean on both changed modules.

## AI transparency

This PR was written with AI assistance and reviewed against the SerpBase API docs and the collector contract before submission (per CONTRIBUTING.md#ai-transparency).
