### PR TITLE
content: acquisition page batch — guides, concepts, research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ __pycache__/
 *.egg-info/
 build/
 dist/
-.eggs/
+.eggs/.abacus-runs/
+.wrangler/
+site/.abacus-runs/

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -50,10 +50,11 @@ export default defineConfig({
 						{ label: 'Getting Started', slug: 'docs/getting-started' },
 						{ label: 'How It Works', slug: 'docs/how-it-works' },
 						{ label: 'CLI Reference', slug: 'docs/cli' },
-						{ label: 'MCP Server', slug: 'docs/mcp-server' },
+						{ label: 'MCP-Based Validation', slug: 'docs/mcp-server' },
 						{ label: 'GEO Loop', slug: 'docs/geo-loop' },
 						{ label: 'Evaluation Harness', slug: 'docs/evaluation' },
 						{ label: 'FAQ', slug: 'docs/faq' },
+						{ label: 'Research', slug: 'research' },
 					],
 				},
 				{
@@ -62,6 +63,15 @@ export default defineConfig({
 						{ label: 'What is GEO?', slug: 'concepts/what-is-geo' },
 						{ label: 'What is AEO?', slug: 'concepts/what-is-aeo' },
 						{ label: 'GEO vs SEO', slug: 'concepts/geo-vs-seo' },
+						{ label: 'What is llms.txt?', slug: 'concepts/what-is-llms-txt' },
+						{ label: 'The 10 GEO Features', slug: 'concepts/geo-features' },
+					],
+				},
+				{
+					label: 'Guides',
+					items: [
+						{ label: 'Rank in ChatGPT Search', slug: 'guides/rank-in-chatgpt-search' },
+						{ label: 'Get Cited by Perplexity', slug: 'guides/rank-in-perplexity' },
 					],
 				},
 				{

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -83,3 +83,28 @@ geo-optimizer-skill (Auriti-Labs, ~644 stars, MIT): CLI + Python library + MCP +
 - https://egeoagents.com/concepts/geo-vs-seo/
 - https://egeoagents.com/compare/e-geo-vs-geo-optimizer-skill/
 - https://egeoagents.com/compare/geo-tools-2026/
+- https://egeoagents.com/concepts/what-is-llms-txt/
+- https://egeoagents.com/concepts/geo-features/
+- https://egeoagents.com/guides/rank-in-chatgpt-search/
+- https://egeoagents.com/guides/rank-in-perplexity/
+- https://egeoagents.com/research/
+
+## Guide: How to Rank in ChatGPT Search (summary)
+
+Allow OAI-SearchBot in robots.txt (it is separate from GPTBot; blocking training does not block search citations). Accelerate Bing discovery with sitemap submission plus IndexNow — Bing is one of the discovery surfaces feeding ChatGPT search. Publish pages that open with a direct 50-170 word answer, carry Article/FAQPage JSON-LD with dates, and keep one canonical entity description across all surfaces. Earn references from the sources ChatGPT already cites. Measure weekly with a fixed query set; single answers are samples, not truth. No tool can guarantee a citation.
+
+## Guide: How to Get Cited by Perplexity (summary)
+
+Measured finding: Perplexity synthesizes from curator sources (aggregators like LibHunt, awesome-lists, niche blogs), not from GitHub stars — projects with 17-37 stars appeared while a 147-star project did not. Playbook: map the cited domains for 8-10 fixed queries weekly; get into those sources; keep PerplexityBot unblocked (check CDN/WAF separately); publish dated comparison pages with stated methodology; keep entity descriptions identical across surfaces. Track % of the fixed query set mentioning you, plus cited-domain lists, over weeks.
+
+## Concept: llms.txt (summary)
+
+llms.txt is a 2024 proposal (llmstxt.org): a Markdown file at the site root giving AI systems a curated index of the most useful content — H1 title, blockquote entity summary, link sections with one-line descriptions — plus an optional llms-full.txt with full text. It is not an official standard and no major engine has committed to honoring it, but it is cheap, harmless, and widely adopted by developer documentation. It complements robots.txt and sitemaps; it does not replace them.
+
+## Concept: The 10 GEO Features (summary)
+
+Canonical list (from GEO_FEATURES in egeo/agents.py, per arXiv:2511.20867 building on KDD 2024): ranking emphasis, user intent, competitive differentiation, social proof, narrative, authority, USPs, urgency, scannability, factual accuracy. Applying all 10 together outperforms individual heuristics. E-GEO's analyzer scores each feature, flags gaps with remediation copy, and prioritizes the three weakest.
+
+## Research (summary)
+
+Lineage: the Princeton GEO study (Aggarwal et al., KDD 2024, peer-reviewed) defined the field; the E-GEO preprint (arXiv:2511.20867, published research, NOT peer-reviewed) adds the applied layer: competitive framing produced the strongest immediate lift, and the universal 10-feature strategy outperformed single heuristics. The evaluation harness measures an LLM-ranker proxy, not real engine rankings.

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -19,6 +19,13 @@ E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered
 - [What is GEO?](https://egeoagents.com/concepts/what-is-geo/): Generative Engine Optimization explained
 - [What is AEO?](https://egeoagents.com/concepts/what-is-aeo/): Answer Engine Optimization explained
 - [GEO vs SEO](https://egeoagents.com/concepts/geo-vs-seo/): differences, overlap, and why to do both
+- [What is llms.txt?](https://egeoagents.com/concepts/what-is-llms-txt/): the llms.txt proposal, honest status, and how to ship one
+- [The 10 GEO Features](https://egeoagents.com/concepts/geo-features/): the research-derived features that make content citable, with implementation guidance
+
+## Guides
+
+- [How to Rank in ChatGPT Search](https://egeoagents.com/guides/rank-in-chatgpt-search/): OAI-SearchBot, Bing/IndexNow discovery, citable content, measurement
+- [How to Get Cited by Perplexity](https://egeoagents.com/guides/rank-in-perplexity/): measured playbook — curator sources, PerplexityBot, dated comparisons
 
 ## Compare
 
@@ -27,6 +34,7 @@ E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered
 
 ## Optional
 
+- [Research behind E-GEO](https://egeoagents.com/research/): Princeton KDD 2024 + the E-GEO preprint, and how findings map to code
 - [Research paper (arXiv:2511.20867)](https://arxiv.org/abs/2511.20867): the research behind E-GEO
 - [GitHub repository](https://github.com/mverab/eGEOagents): source code, issues, discussions
 - [skills.sh collection](https://skills.sh/mverab/egeoagents): Claude Code skills distribution

--- a/site/src/content/docs/concepts/geo-features.md
+++ b/site/src/content/docs/concepts/geo-features.md
@@ -1,0 +1,95 @@
+---
+title: The 10 GEO Features That Make Content Citable
+description: The 10 research-derived GEO features, what each one means, and exactly how to implement it — the same checklist E-GEO's analyzer scores against.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "The 10 GEO Features That Make Content Citable",
+        "description": "The 10 research-derived GEO features with implementation guidance — the checklist E-GEO's analyzer scores against.",
+        "url": "https://egeoagents.com/concepts/geo-features/",
+        "datePublished": "2026-08-11",
+        "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]},
+        "citation": "https://arxiv.org/abs/2511.20867"
+      }
+---
+
+The E-GEO research preprint ([arXiv:2511.20867](https://arxiv.org/abs/2511.20867)), building on the Princeton GEO study ([Aggarwal et al., KDD 2024](https://arxiv.org/abs/2311.09735)), identifies 10 content features that consistently appear in content that AI answer engines rank and cite highly. These are the same 10 features E-GEO's analyzer scores — the list below is the canonical definition used by the code.
+
+## 1. Ranking emphasis
+
+Frame the content as a leading choice for a specific use case ("best for X"). Engines prefer sources that take a clear position over sources that list options neutrally.
+
+**Implement:** state plainly what the thing is best at, in the first paragraph.
+
+## 2. User intent
+
+Open by directly answering the question the reader actually asked. If the page targets "how to rank in Perplexity", the first sentence should answer it, not set scene.
+
+**Implement:** a 50–170 word answer block at the top of every page.
+
+## 3. Competitive differentiation
+
+Concrete advantages over typical alternatives — without needing to name competitors. "The only one that does X" claims must be verifiable or they destroy trust.
+
+**Implement:** one honest differentiator, stated as fact you can defend.
+
+## 4. Social proof
+
+Trust signals: user counts, ratings, testimonials. **Never fabricated** — invented proof is a disqualifier when checked.
+
+**Implement:** real numbers with dates, or omit the claim.
+
+## 5. Narrative
+
+A persuasive, benefit-led flow instead of a feature dump. Engines extract better answers from coherent prose than from fragments.
+
+**Implement:** problem → mechanism → outcome, in that order.
+
+## 6. Authority
+
+Expert, confident phrasing with verifiable specifics: credentials, methodology, datasets, dates.
+
+**Implement:** say how you know — "measured weekly since 2026-08" beats "industry-leading".
+
+## 7. Unique selling points
+
+Make USPs explicit and scannable as bullets. If a reader (or model) can't list your USPs after one pass, you don't have any on the page.
+
+**Implement:** a short bullet list of differentiators, high on the page.
+
+## 8. Urgency
+
+Genuine urgency or scarcity where it truly exists — a dated offer, a real deadline. Fake countdowns and manufactured scarcity are trust poison, and engines increasingly discount them.
+
+**Implement:** use only when literally true.
+
+## 9. Scannability
+
+Headings, bullet lists, short paragraphs. Scannable structure is what makes a passage liftable into an answer with attribution intact.
+
+**Implement:** descriptive H2s; no paragraph over ~4 lines.
+
+## 10. Factual accuracy
+
+Concrete, verifiable facts — numbers, units, names — and no vague hype. Models cross-check claims against other sources; consistency across surfaces compounds trust.
+
+**Implement:** every number has a source or a date.
+
+## How the features are scored
+
+E-GEO's analyzer scores each feature, flags anything below threshold as a gap with remediation copy, and prioritizes the three weakest features for rewriting. Applying all 10 together outperforms individual heuristics in the paper's experiments — the features interact; a page strong on authority but weak on scannability still loses citations.
+
+Try it on your own page:
+
+```bash
+egeo optimize path/to/page.md
+```
+
+---
+
+**In short:** 10 research-derived features — ranking emphasis, user intent, competitive differentiation, social proof, narrative, authority, USPs, urgency, scannability, factual accuracy — predict citability better than any single trick, and they interact. **E-GEO** scores all 10 and rewrites for the weakest three: [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).

--- a/site/src/content/docs/concepts/what-is-llms-txt.md
+++ b/site/src/content/docs/concepts/what-is-llms-txt.md
@@ -1,0 +1,58 @@
+---
+title: What is llms.txt?
+description: llms.txt explained — the proposal, the format, what it can and cannot do, and how to ship one on your own site in minutes.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is llms.txt?",
+            "acceptedAnswer": {"@type": "Answer", "text": "llms.txt is a proposed convention (llmstxt.org, 2024): a Markdown file at a site's root that gives AI systems a curated, prioritized index of the site's most useful content, plus an optional llms-full.txt containing full text. It is a proposal, not an official standard — no major engine has committed to honoring it — but it is cheap, harmless, and already adopted by many developer documentation sites."}
+          }
+        ]
+      }
+---
+
+**llms.txt** is a proposed convention: a Markdown file served at `/llms.txt` that gives AI systems a clean, prioritized map of your site's most useful content — instead of forcing them to parse navigation, ads, and boilerplate from raw HTML.
+
+## The format
+
+A `llms.txt` file is Markdown with three parts:
+
+1. **H1 title** — the project or site name.
+2. **Blockquote summary** — one short paragraph stating what the site/product is. This is the entity definition an LLM reads first.
+3. **Link sections** — `## Docs`, `## Concepts`, `## Optional` — with `- [Title](url): one-line description` entries.
+
+A companion file, `/llms-full.txt`, contains the full text of the key pages so an agent can ingest everything in one fetch.
+
+## Honest status: proposal, not standard
+
+- llms.txt was proposed at [llmstxt.org](https://llmstxt.org/) in 2024. **No major AI engine has committed to honoring it.**
+- It does not replace `robots.txt` (access control) or sitemaps (crawl discovery). It is a *content curation* layer.
+- Agentic tools and IDE assistants already consume it; adoption by developer-documentation sites is broad and growing.
+- Cost of shipping one: minutes. Risk: none. Expected value: positive but unproven at engine level — treat it as cheap insurance, not a ranking factor.
+
+## A real example
+
+This site's own [`llms.txt`](/llms.txt) declares the entity in the blockquote and links every docs, concept, and comparison page with one-line descriptions. The full-text companion lives at [`/llms-full.txt`](/llms-full.txt).
+
+## How to write a good one
+
+- **One canonical entity sentence**, byte-identical to your README and listings.
+- **Curate, don't dump** — link your 10–20 most useful pages, not your whole sitemap.
+- **One-line descriptions** that carry the claim an engine would need to cite you accurately.
+- **Keep it fresh** — regenerate or review it whenever you ship pages.
+
+## How E-GEO uses it
+
+E-GEO's schema/affordance step generates `llms.txt` and JSON-LD alongside rewritten content, and this site ships both files at the root. The toolkit's position is the honest one: llms.txt is a low-cost affordance for agents, complementary to sitemaps and structured data — not a substitute for being cited by real sources.
+
+---
+
+**In short:** llms.txt is a Markdown index at your site root that tells AI systems what content matters and what your entity is. It's an unofficial proposal with zero cost and growing agent-side adoption — ship it, keep it curated and fresh, but don't expect it to substitute for real citations. **E-GEO** generates it as part of its optimization pipeline: [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).

--- a/site/src/content/docs/guides/rank-in-chatgpt-search.md
+++ b/site/src/content/docs/guides/rank-in-chatgpt-search.md
@@ -1,0 +1,74 @@
+---
+title: How to Rank in ChatGPT Search (2026 Guide)
+description: A practical, honest guide to getting your site discovered and cited by ChatGPT search — crawlers, Bing, structured data, and citable content.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "How to Rank in ChatGPT Search (2026 Guide)",
+        "description": "Practical guide to getting discovered and cited by ChatGPT search: OAI-SearchBot, Bing discovery, structured data, and citable content.",
+        "url": "https://egeoagents.com/guides/rank-in-chatgpt-search/",
+        "datePublished": "2026-08-11",
+        "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]}
+      }
+---
+
+**Last verified: 2026-08-11.** ChatGPT search does not publish a ranking algorithm, so this guide only contains mechanisms that are documented, observable, or measurable — plus what we verify weekly on our own domain.
+
+## How ChatGPT search discovers content
+
+ChatGPT search combines real-time retrieval with its model knowledge. The discovery side is crawlable and observable:
+
+1. **OAI-SearchBot** — OpenAI's search crawler. If it cannot fetch your page, ChatGPT search cannot cite the live version of it. OpenAI documents separate user agents for search (`OAI-SearchBot`), training (`GPTBot`), and user-triggered fetches (`ChatGPT-User`).
+2. **Bing's index** — Bing is one of the discovery surfaces feeding ChatGPT search. Sites that Bing indexes quickly tend to surface in ChatGPT answers sooner. This is observable: notify Bing and watch.
+3. **Third-party sources** — ChatGPT answers frequently cite review sites, directories, and comparison pages rather than product homepages. Your own page is one candidate source among many.
+
+## Step 1 — Allow the search crawler (not necessarily the training one)
+
+In `robots.txt`:
+
+```text
+User-agent: OAI-SearchBot
+Allow: /
+```
+
+`OAI-SearchBot` (search citations) and `GPTBot` (model training) are separate tokens. Blocking `GPTBot` does not block search citations. Also check your CDN or WAF: bot-fighting rules can silently block search crawlers even when `robots.txt` allows them — verify with a real fetch, not just the file.
+
+## Step 2 — Accelerate Bing discovery
+
+- Submit your sitemap in **Bing Webmaster Tools**.
+- Use **IndexNow**: host a key file at your root and POST new or updated URLs to `api.indexnow.org`. An HTTP 200 means "URL received", not "indexed" — measure the outcome separately.
+- E-GEO's own site does both automatically on every deploy; the script is in the repository (`site/indexnow.sh`).
+
+## Step 3 — Make pages citable
+
+Answer engines lift self-contained passages:
+
+- Open each page with a direct 50–170 word answer to the query it targets.
+- Use descriptive headings, tables with dates, and FAQ sections with `FAQPage` JSON-LD.
+- Add `Article`/`TechArticle` schema with `datePublished` and `dateModified` — freshness is a selection signal.
+- Keep one canonical entity description identical across your site, README, and listings.
+
+## Step 4 — Borrow authority you don't have yet
+
+ChatGPT often cites whoever already ranks for the question. Getting referenced by those sources (directories, curated lists, niche blogs) moves you into the candidate set faster than waiting for direct citation.
+
+## Step 5 — Measure, don't assume
+
+- Ask ChatGPT a fixed set of category questions weekly and record whether you appear and which sources get cited.
+- Watch Bing Webmaster Tools and your server logs for `OAI-SearchBot` fetches.
+- Treat any single answer as a sample, not ground truth — answers vary run to run.
+
+## What not to trust
+
+- No tool can guarantee a ChatGPT citation.
+- Blocking AI training crawlers is a rights choice; it is not a search-visibility strategy.
+- "AI SEO" services promising guaranteed placement are selling something that does not exist.
+
+---
+
+**In short:** allow `OAI-SearchBot`, get Bing to index you fast (sitemap + IndexNow), publish citable dated content with schema, earn references from the sources ChatGPT already cites, and measure with a fixed query set. **E-GEO** automates the content and schema side of this — the analyze → rewrite → JSON-LD pipeline plus a monitoring loop — open source, MIT: [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).

--- a/site/src/content/docs/guides/rank-in-perplexity.md
+++ b/site/src/content/docs/guides/rank-in-perplexity.md
@@ -1,0 +1,73 @@
+---
+title: How to Get Cited by Perplexity (Measured Playbook)
+description: A playbook for Perplexity citations built from weekly measurements — which sources Perplexity cites, why stars don't matter, and what to publish.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "How to Get Cited by Perplexity (Measured Playbook)",
+        "description": "A Perplexity citation playbook built from weekly measurements: curator sources, PerplexityBot, dated comparison pages, and entity consistency.",
+        "url": "https://egeoagents.com/guides/rank-in-perplexity/",
+        "datePublished": "2026-08-11",
+        "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]}
+      }
+---
+
+**Last verified: 2026-08-11.** This playbook comes from running a fixed query set against Perplexity every week and recording which sources it cites — including a month where our own project had perfect on-page metadata and zero mentions.
+
+## The finding that changes everything
+
+Perplexity does not crawl GitHub and sort by stars. In our measured category (open-source GEO tools), projects with **17–37 stars appeared** in answers while a project with **147 stars did not** — for over a month. The difference was not product quality or README optimization. It was presence in the sources Perplexity synthesizes from:
+
+- **Aggregators** (LibHunt was the top-cited source in our category).
+- **Curated lists** (awesome-* repositories with their own authority).
+- **Niche blogs and comparison articles** with dates and concrete criteria.
+
+If those sources don't mention you, Perplexity doesn't either.
+
+## Step 1 — Map what Perplexity cites for your queries
+
+1. Write down 8–10 fixed queries your buyers ask (category, comparison, how-to).
+2. Run them weekly. Record the **cited domains**, not just whether you appear.
+3. The cited domains are your distribution target list. This is observable, not speculative — one query run shows you exactly which curators matter in your niche.
+
+## Step 2 — Get into those sources
+
+- Submit to the aggregators and directories that appear in answers.
+- Contribute honest entries to curated lists (read each list's inclusion criteria first; a silently-closed PR is a signal to open an issue asking for criteria, not to spam).
+- Publish the kind of third-party-style content yourself: dated comparisons that credit competitors. Pages with a visible "Last verified" date and a stated methodology are easier for an engine to trust and cite.
+
+## Step 3 — Keep PerplexityBot unblocked
+
+```text
+User-agent: PerplexityBot
+Allow: /
+```
+
+Check your CDN/WAF separately — `robots.txt` permission means nothing if a bot-fighting rule blocks the fetch upstream.
+
+## Step 4 — Publish citable pages on your own domain
+
+Perplexity cites pages, not repositories. Each target query deserves a page with:
+
+- a direct answer in the first 50–170 words;
+- a stated methodology ("how we built this comparison");
+- a visible verification date;
+- `Article` or `FAQPage` JSON-LD;
+- links to primary sources.
+
+## Step 5 — Entity consistency
+
+Use one identical description of your product across your site, GitHub, package registries, and every listing. Answer engines build entity confidence from repetition across independent surfaces; drift between descriptions reads as uncertainty.
+
+## What our measurements look like
+
+We track 10 fixed queries (2 branded, 8 generic) weekly against Perplexity and snapshot the results. The metric that matters is **% of the fixed set mentioning you**, plus the cited-domain list. One run is a sample; the trend over weeks is the signal.
+
+---
+
+**In short:** Perplexity visibility is earned off your own site first — get into the curator sources it cites, keep `PerplexityBot` unblocked, publish dated citable pages, and measure weekly with a fixed query set. **E-GEO** implements this loop as open-source tooling (fixed query sets, snapshot diffs, content optimization): [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).

--- a/site/src/content/docs/research.md
+++ b/site/src/content/docs/research.md
@@ -1,0 +1,59 @@
+---
+title: Research Behind E-GEO
+description: The research lineage of E-GEO — the Princeton KDD 2024 GEO study, the E-GEO preprint (arXiv:2511.20867), and how the findings map to code.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Research Behind E-GEO",
+        "description": "The research lineage of E-GEO: the Princeton KDD 2024 GEO study, the E-GEO preprint, and how findings map to the toolkit's code.",
+        "url": "https://egeoagents.com/research/",
+        "datePublished": "2026-08-11",
+        "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]}
+      }
+---
+
+E-GEO is research-grounded in a specific, verifiable way. This page states exactly what the research says, what status each paper has, and where each finding lands in code.
+
+## The lineage
+
+### 1. Princeton GEO study — the foundation
+
+[Generative Engine Optimization](https://arxiv.org/abs/2311.09735) (Aggarwal et al., **KDD 2024** — a peer-reviewed venue) defined the field: it showed that specific, measurable content changes (adding citations, statistics, authoritative phrasing) shift how generative engines select and rank sources, with visibility improvements measurable against baselines. Every GEO tool, including this one, builds on it.
+
+### 2. E-GEO preprint — the applied layer
+
+The [E-GEO preprint](https://arxiv.org/abs/2511.20867) (arXiv:2511.20867) extends that line with an applied focus. arXiv is a preprint server: the paper is **published research, not peer-reviewed** — we describe it that way everywhere, and you should hold us to it.
+
+What it reports:
+
+1. **Competitive framing** produced the strongest immediate ranking lift among the strategies tested.
+2. A **universal strategy** (all 10 features applied together) outperformed individual heuristics by a wide margin.
+3. The **10 features** — ranking emphasis, user intent, competitive differentiation, social proof, narrative, authority, USPs, urgency, scannability, factual accuracy — consistently appeared in higher-ranking content across ChatGPT, Perplexity, and Gemini.
+
+## From paper to code
+
+| Research finding | Where it lives in E-GEO |
+|---|---|
+| 10 GEO features | `GEO_FEATURES` in `egeo/agents.py` — the analyzer's scoring checklist ([explained](/concepts/geo-features/)) |
+| Universal strategy > single heuristics | The rewriter applies all features in one pass instead of cherry-picking |
+| Competitive framing's outsized lift | Ranker stage: simulates engine ranking against competitors and explains gaps |
+| Measurable, not vibes | [Reproducible evaluation harness](/docs/evaluation/) — offline, deterministic, runs in CI |
+
+## Honest limitations
+
+- The evaluation harness measures an **LLM-ranker proxy**, not real engine rankings. It tells you the rewrite moved in the right direction; it cannot prove ChatGPT will cite you. [Full disclosure in the evaluation docs](/docs/evaluation/).
+- Engine behavior changes constantly. Findings are snapshots; that is why E-GEO ships a [continuous loop](/docs/geo-loop/) instead of a one-time fix.
+- arXiv:2511.20867 is a preprint. The peer-reviewed anchor in this lineage is the Princeton KDD 2024 study.
+
+## Why publish this page at all
+
+Because a GEO tool whose own claims can't be traced to sources is selling the exact disease it claims to cure. Every claim on this site links to its ground truth — code, paper, or measured data — and the [comparison pages](/compare/geo-tools-2026/) credit competitors' real strengths, including the one with more stars than us.
+
+---
+
+**In short:** E-GEO stands on the peer-reviewed Princeton GEO study (KDD 2024) plus the project's own applied preprint (arXiv:2511.20867), and every finding maps to a specific, inspectable part of the codebase. Verify, don't trust: [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).


### PR DESCRIPTION
## Summary
Expands the organic acquisition surface from 13 to 18 indexable URLs in one pass, following the planned information architecture:

- `/guides/rank-in-chatgpt-search/` — OAI-SearchBot, Bing/IndexNow discovery path, citable content patterns, measurement
- `/guides/rank-in-perplexity/` — curator-source playbook grounded in our own weekly measurements
- `/concepts/what-is-llms-txt/` — honest treatment of the proposal (not a standard)
- `/concepts/geo-features/` — canonical 10 features taken from `GEO_FEATURES` in `egeo/agents.py`
- `/research/` — research lineage with honest preprint framing and paper→code mapping

Also updates sidebar, `llms.txt`, `llms-full.txt`, and fixes the stale MCP sidebar label.

## Verification
- `npm run build`: 19 pages
- `bash verify.sh`: all checks pass
- All 5 new pages present in sitemap with JSON-LD
- All external links return HTTP 200

## Measurement
After deploy, these URLs enter the indexation loop (IndexNow via CI + Search Console snapshot) and the weekly fixed-query visibility measurement.