### PR TITLE
content: canonicalize GEO-feature references

### DIFF
--- a/site/src/content/docs/concepts/what-is-geo.md
+++ b/site/src/content/docs/concepts/what-is-geo.md
@@ -38,7 +38,7 @@ GEO targets how a large language model perceives content, not how a crawler inde
 
 ## The 10 GEO features
 
-Research behind the E-GEO toolkit ([arXiv:2511.20867](https://arxiv.org/abs/2511.20867)) identified 10 features that consistently appear in higher-ranking content across ChatGPT, Perplexity, and Gemini: ranking emphasis, user intent alignment, competitive differentiation, social proof, compelling narrative, authoritativeness, unique selling points, urgency signals, scannable format, and factual accuracy. Applying all 10 together outperforms any single heuristic.
+Research behind the E-GEO toolkit ([arXiv:2511.20867](https://arxiv.org/abs/2511.20867)) identified 10 features that consistently appear in higher-ranking content across ChatGPT, Perplexity, and Gemini. Applying all 10 together outperforms any single heuristic. The canonical list, with per-feature implementation guidance: [The 10 GEO Features](/concepts/geo-features/).
 
 ## GEO in practice
 

--- a/site/src/content/docs/docs/how-it-works.md
+++ b/site/src/content/docs/docs/how-it-works.md
@@ -42,7 +42,7 @@ The same four agents run either **in-process** through the Python runtime behind
 
 ### 1. Analyzer
 
-Extracts content, scores it against the 10 universal GEO features, identifies gaps, and writes `analysis.json`:
+Extracts content, scores it against the [10 universal GEO features](/concepts/geo-features/), identifies gaps, and writes `analysis.json`:
 
 ```json
 {


### PR DESCRIPTION
## Why
The new `/concepts/geo-features/` page is the canonical deep page for the 10 features. `what-is-geo` previously carried its own (inconsistent) feature list, creating a cannibalization risk and a factual drift vs `GEO_FEATURES` in code.

## Changes
- `what-is-geo`: condensed features section, links to canonical page
- `how-it-works`: analyzer description links to canonical page

## Verification
- `npm run build` + `bash verify.sh`: green