### PR TITLE
chore: add Gumroad custom funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://verabadias.gumroad.com/']


### PR DESCRIPTION
## Why
The Sponsor button currently points to a GitHub Sponsors listing that does not exist yet (account-level activation pending, requires owner bank/tax data). Adding the Gumroad custom link makes the button functional immediately.

## Change
- `custom: [https://verabadias.gumroad.com/]` in `.github/FUNDING.yml`

When the Sponsors listing is approved, both options remain available — no conflict.