### PR TITLE
chore: add Stripe GEO audit link to funding options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ['https://verabadias.gumroad.com/']
+custom: ['https://buy.stripe.com/dRm5kD7CrcPs8ILaco3Ru0j', 'https://verabadias.gumroad.com/']


### PR DESCRIPTION
Stripe (~3%) replaces Gumroad (10%) as the rail for the productized GEO audit service. Donations stay on GitHub Sponsors (0%). Verified via Stripe API: link active, 199.00 USD, livemode.