### PR TITLE
test: add CLI optimize parser tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from egeo.cli import build_parser
+
+
+def test_optimize_command_parser():
+    parser = build_parser()
+
+    args = parser.parse_args([
+        "optimize",
+        "example.md"
+    ])
+
+    assert args.cmd == "optimize"
+    assert args.input == "example.md"
+    assert args.out_dir == "geo-output"
+    assert args.schema_type == "Article"
+    assert args.runtime == "python"
+
+
+def test_optimize_command_custom_options():
+    parser = build_parser()
+
+    args = parser.parse_args([
+        "optimize",
+        "content.md",
+        "--out-dir",
+        "output",
+        "--schema-type",
+        "FAQPage",
+        "--runtime",
+        "python"
+    ])
+
+    assert args.input == "content.md"
+    assert args.out_dir == "output"
+    assert args.schema_type == "FAQPage"
+    assert args.runtime == "python"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,10 +27,10 @@ def test_optimize_command_custom_options():
         "--schema-type",
         "FAQPage",
         "--runtime",
-        "python"
+        "other"
     ])
 
     assert args.input == "content.md"
     assert args.out_dir == "output"
     assert args.schema_type == "FAQPage"
-    assert args.runtime == "python"
+    assert args.runtime == "other"


### PR DESCRIPTION
## Description
Adds unit tests for the `egeo optimize` argparse contract (`build_parser`).

This is a test-only PR. It does **not** implement markdown frontmatter support (issue #2); the source branch name is a leftover.

Maintainer follow-up on top of the original commit: the custom-options test now uses a non-default `--runtime` value, and the file has a trailing newline.

## Type of Change
- [x] Tests

## GEO Impact
- [x] No GEO methodology changes

## Testing
- [x] `pytest tests/test_cli.py` — 2 passed locally against current `egeo.cli`

## Checklist
- [x] Tests assert real parser defaults and one non-default override path
- [x] Parser-only (does not run the optimize pipeline)

## Additional Notes
Canonical PR for this commit. #29 was closed as a duplicate (same SHA).
