### PR TITLE
feat(loop): add portable project contract

### DIFF
--- a/.claude/skills/geo-loop/SKILL.md
+++ b/.claude/skills/geo-loop/SKILL.md
@@ -41,6 +41,9 @@ not in a runnable state (`egeo loop doctor` explains why).
 
 - `$EGEO_HOME/domains/<domain>/README.md` — charter, cadence, focus, backlog,
   Timeline (the last entry tells you where the previous run stopped).
+- `$EGEO_HOME/project.yaml` — when present, the validated project identity,
+  canonical domain, tracked queries/pages, and anti-spam/canibalization
+  guardrails. `egeo loop doctor` is the source of truth for its validity.
 - `$EGEO_HOME/data/<collector>/*.jsonl` — fresh ground truth.
 - `$EGEO_HOME/signals/` and `$EGEO_HOME/docs/` — what is already known, so you
   dedupe instead of duplicating.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Test portable loop contract
+        run: python -m unittest discover -s tests -v
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ All loop state lives **outside the repo**, in the workspace resolved from
 $EGEO_HOME/
 ├── LOG.md                        # append-only activity feed (one line per event)
 ├── config.yaml                   # cadence, models, budgets, scaling weights
+├── project.yaml                  # portable project identity, targets, guardrails
 ├── SUBSTRATE.md                  # the contract, vendored on bootstrap
 ├── signals/<slug>.md             # evidence — deduped, frequency-counted
 ├── docs/<slug>.md                # durable knowledge — analyses, decisions
@@ -332,6 +333,13 @@ $EGEO_HOME/
 
 The layout and the artifact rules are defined by [`SUBSTRATE.md`](SUBSTRATE.md)
 and mechanically enforced by `python -m egeo.substrate_lint`.
+
+`project.yaml` is optional during migration. When present, it is the validated
+source for the active project's canonical domain, tracked queries, tracked
+pages, and anti-spam/canibalization guardrails. `config.yaml` remains the
+machine-facing loop configuration. If `project.yaml` is absent, collectors use
+the legacy `config.yaml` fields and `egeo loop doctor` reports that fallback.
+See [`examples/project.yaml`](examples/project.yaml) for the portable contract.
 
 ### Commands
 

--- a/collectors/README.md
+++ b/collectors/README.md
@@ -12,7 +12,9 @@ A collector in this directory MUST:
 1. **Be deterministic and LLM-free.** No model calls, no prompts, no
    interpretation. Given the same input it produces the same record.
 2. **Read configuration from the workspace, credentials from the environment.**
-   Inputs come from `$EGEO_HOME/config.yaml` (`collectors.<name>.*`); secrets
+   When `$EGEO_HOME/project.yaml` exists and validates, project identity,
+   queries, and tracked URLs come from that contract. Otherwise inputs come
+   from `$EGEO_HOME/config.yaml` (`collectors.<name>.*`); secrets
    come from env vars (`BRAVE_API_KEY`). Nothing is read from the repo tree and
    secret values are never printed or logged.
 3. **Append versioned JSONL.** One JSON object per observation, appended to

--- a/collectors/page.py
+++ b/collectors/page.py
@@ -263,10 +263,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     home = common.ensure_workspace()
     try:
         config = workspace.load_config(home)
+        project = workspace.load_project_config(home)
     except (OSError, ValueError) as exc:
         return common.fail(str(exc))
 
-    urls = args.urls or list(workspace.config_get(config, "collectors.page.urls", []) or [])
+    inputs = workspace.project_inputs(project, config)
+    urls = args.urls or inputs["urls"]
     budget = workspace.config_get(config, "budgets.pages_per_day", None)
 
     try:

--- a/collectors/serp.py
+++ b/collectors/serp.py
@@ -331,13 +331,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     home = common.ensure_workspace()
     try:
         config = workspace.load_config(home)
+        project = workspace.load_project_config(home)
     except (OSError, ValueError) as exc:
         return common.fail(str(exc))
 
-    queries = args.queries or list(workspace.config_get(config, "collectors.serp.queries", []) or [])
-    target_domain = args.target_domain or str(
-        workspace.config_get(config, "collectors.serp.target_domain", "") or ""
-    )
+    inputs = workspace.project_inputs(project, config)
+    queries = args.queries or inputs["queries"]
+    target_domain = args.target_domain or str(inputs["target_domain"] or "")
     engine = args.engine or str(workspace.config_get(config, "collectors.serp.engine", ENGINE) or ENGINE)
     budget = workspace.config_get(config, "budgets.queries_per_day", None)
 

--- a/egeo/loop.py
+++ b/egeo/loop.py
@@ -175,12 +175,14 @@ def candidate_signals(deltas: List[Dict[str, Any]]) -> List[str]:
 
 def build_plan(domain: str, home: Path) -> Dict[str, Any]:
     """Assemble the run plan for ``domain``. Pure read; never writes."""
+    project = workspace.load_project_config(home)
     readme = workspace.domain_readme(domain, home)
     plan: Dict[str, Any] = {
         "domain": domain,
         "workspace": str(home),
         "charter_path": str(readme),
         "charter_exists": readme.is_file(),
+        "project": workspace.project_summary(project, home),
     }
     if readme.is_file():
         plan.update(parse_charter(readme.read_text(encoding="utf-8")))
@@ -195,6 +197,9 @@ def _print_plan(plan: Dict[str, Any], dry_run: bool) -> None:
     mode = "DRY RUN — nothing will be written" if dry_run else "run plan"
     print(f"egeo loop run: {plan['domain']} ({mode})")
     print(f"  workspace:     {plan['workspace']}")
+    project = plan.get("project", {})
+    print(f"  project:       {project.get('id') or 'legacy'} ({project.get('config_source')})")
+    print(f"  project stats: {project.get('active_queries', 0)} active querie(s), {project.get('active_pages', 0)} active page(s)")
     print(f"  charter:       {plan['charter_path']}")
     if not plan["charter_exists"]:
         print("  charter:       MISSING — create it (see egeo-core backlog) before running the agent")
@@ -271,6 +276,17 @@ def diagnose(home: Path) -> Tuple[List[str], List[str], Dict[str, Any]]:
                 problems.append(f"{key} must be a positive integer, got {value!r}")
         facts["models"] = workspace.config_get(config, "models", {})
 
+    project: Optional[Dict[str, Any]] = None
+    try:
+        project = workspace.load_project_config(home)
+    except workspace.ProjectConfigError as exc:
+        problems.append(str(exc))
+    else:
+        project_facts = workspace.project_summary(project, home)
+        facts.update({f"project.{key}": value for key, value in project_facts.items()})
+        if project is None:
+            warnings.append("project.yaml is absent: legacy config.yaml fallback is active")
+
     violations, artifacts, domains = substrate_lint.lint(home)
     facts["artifacts"] = artifacts
     facts["domains"] = domains
@@ -316,7 +332,11 @@ def cmd_run(args: argparse.Namespace) -> int:
     else:
         workspace.bootstrap(home)
 
-    plan = build_plan(args.domain, home)
+    try:
+        plan = build_plan(args.domain, home)
+    except workspace.ProjectConfigError as exc:
+        print(f"egeo loop run: invalid project contract: {exc}", file=sys.stderr)
+        return 1
     if args.json:
         print(json.dumps(plan, indent=2, sort_keys=True))
     else:
@@ -366,6 +386,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
           f"{facts.get('streams', 0)} data stream(s)")
     print(f"  budgets:   queries/day={facts.get('budgets.queries_per_day')} "
           f"pages/day={facts.get('budgets.pages_per_day')}")
+    print(f"  project:   {facts.get('project.id') or 'legacy'} ({facts.get('project.config_source', 'unknown')})")
+    print(f"  targets:   queries={facts.get('project.active_queries', 0)} pages={facts.get('project.active_pages', 0)}")
     print(f"  reflect:   auto_apply={facts.get('reflect.auto_apply')}")
     print(f"  BRAVE_API_KEY: {'set' if facts.get('brave_api_key_set') else 'not set'}")
     overrides = facts.get("prompt_overrides") or []

--- a/egeo/workspace.py
+++ b/egeo/workspace.py
@@ -25,9 +25,11 @@ and ``egeo optimize`` behave exactly as before loop mode existed.
 from __future__ import annotations
 
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from . import repo_root
 
@@ -45,8 +47,13 @@ LAYOUT_DIRS = ("signals", "docs", "data", "domains", "prompts")
 MACHINERY_DOMAIN = "egeo-core"
 
 CONFIG_NAME = "config.yaml"
+PROJECT_CONFIG_NAME = "project.yaml"
 LOG_NAME = "LOG.md"
 SUBSTRATE_NAME = "SUBSTRATE.md"
+PROJECT_SCHEMA_VERSION = 1
+_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_SECRET_KEY_RE = re.compile(r"(?:api[_-]?key|secret|token|password|credential|private[_-]?key|oauth)", re.I)
+_QUERY_CLASSES = {"branded", "generic", "commercial", "informational", "navigational", "other"}
 
 _LOG_HEADER = """# LOG
 
@@ -244,6 +251,223 @@ def append_log(domain: str, event: str, summary: str, home: Optional[Path] = Non
     with log.open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")
     return line
+
+
+def project_config_path(home: Optional[Path] = None) -> Path:
+    """Return the active project's declarative contract path."""
+    return (home or resolve_home()) / PROJECT_CONFIG_NAME
+
+
+class ProjectConfigError(ValueError):
+    """Raised when the portable project contract is absent or invalid."""
+
+
+def _secret_paths(value: Any, path: str = "") -> List[str]:
+    """Find credential-like keys without returning their values."""
+    found: List[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            if _SECRET_KEY_RE.search(str(key)):
+                found.append(child_path)
+            else:
+                found.extend(_secret_paths(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(_secret_paths(child, f"{path}[{index}]"))
+    return found
+
+
+def _normalized_domain(value: str) -> str:
+    return (value or "").strip().lower().removeprefix("www.").rstrip(".")
+
+
+def _is_http_url(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc) and not parsed.username and not parsed.password
+
+
+def validate_project_config(data: Any) -> List[str]:
+    """Return deterministic, value-safe validation errors for project.yaml."""
+    errors: List[str] = []
+    if not isinstance(data, dict):
+        return ["root must be a mapping"]
+    if data.get("schema_version") != PROJECT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {PROJECT_SCHEMA_VERSION}")
+    secret_paths = _secret_paths(data)
+    if secret_paths:
+        errors.append("credential-like keys are forbidden: " + ", ".join(secret_paths))
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        errors.append("project must be a mapping")
+        project = {}
+    for key in ("id", "name", "repository", "canonical_domain", "canonical_url", "language"):
+        if not str(project.get(key) or "").strip():
+            errors.append(f"project.{key} is required")
+    project_id = str(project.get("id") or "")
+    if project_id and not _PROJECT_ID_RE.fullmatch(project_id):
+        errors.append("project.id must use lowercase letters, digits, and hyphens")
+    for key in ("repository", "canonical_url"):
+        if project.get(key) and not _is_http_url(project.get(key)):
+            errors.append(f"project.{key} must be an http(s) URL")
+    canonical_url = str(project.get("canonical_url") or "")
+    canonical_domain = _normalized_domain(str(project.get("canonical_domain") or ""))
+    if canonical_url and canonical_domain and _normalized_domain(urlparse(canonical_url).hostname or "") != canonical_domain:
+        errors.append("project.canonical_domain does not match project.canonical_url")
+
+    pages = data.get("pages", [])
+    if not isinstance(pages, list):
+        errors.append("pages must be a list")
+        pages = []
+    page_ids: set[str] = set()
+    page_urls: Dict[str, str] = {}
+    for index, page in enumerate(pages):
+        prefix = f"pages[{index}]"
+        if not isinstance(page, dict):
+            errors.append(f"{prefix} must be a mapping")
+            continue
+        page_id = str(page.get("id") or "")
+        if not page_id:
+            errors.append(f"{prefix}.id is required")
+        elif page_id in page_ids:
+            errors.append(f"duplicate page id: {page_id}")
+        else:
+            page_ids.add(page_id)
+        url = page.get("url")
+        if not _is_http_url(url):
+            errors.append(f"{prefix}.url must be an http(s) URL")
+        elif bool(page.get("active", True)):
+            normalized_url = str(url).split("#", 1)[0].rstrip("/") or "/"
+            if normalized_url in page_urls:
+                errors.append(f"duplicate active page URL: {page_urls[normalized_url]} and {page_id}")
+            else:
+                page_urls[normalized_url] = page_id
+
+    queries = data.get("queries", [])
+    if not isinstance(queries, list):
+        errors.append("queries must be a list")
+        queries = []
+    query_ids: set[str] = set()
+    ownership: Dict[tuple[str, str], List[tuple[str, str]]] = {}
+    for index, query in enumerate(queries):
+        prefix = f"queries[{index}]"
+        if not isinstance(query, dict):
+            errors.append(f"{prefix} must be a mapping")
+            continue
+        query_id = str(query.get("id") or "")
+        if not query_id:
+            errors.append(f"{prefix}.id is required")
+        elif query_id in query_ids:
+            errors.append(f"duplicate query id: {query_id}")
+        else:
+            query_ids.add(query_id)
+        active = bool(query.get("active", True))
+        text = str(query.get("text") or "").strip()
+        if active and not text:
+            errors.append(f"{prefix}.text is required for active queries")
+        query_class = str(query.get("class") or "").strip().lower()
+        if active and query_class not in _QUERY_CLASSES:
+            errors.append(f"{prefix}.class must be one of {sorted(_QUERY_CLASSES)}")
+        target_pages = query.get("target_pages", [])
+        if not isinstance(target_pages, list) or any(not isinstance(item, str) for item in target_pages):
+            errors.append(f"{prefix}.target_pages must be a list of page IDs")
+            target_pages = []
+        for page_id in target_pages:
+            if page_id not in page_ids:
+                errors.append(f"{prefix}.target_pages references unknown page: {page_id}")
+            if active and query.get("intent"):
+                ownership.setdefault((page_id, str(query.get("intent"))), []).append(
+                    (query_id, str(query.get("experiment") or ""))
+                )
+    for (page_id, intent), owners in ownership.items():
+        if len(owners) > 1 and not all(experiment for _, experiment in owners):
+            errors.append(f"canonical ownership collision: page {page_id!r}, intent {intent!r}, queries {[query_id for query_id, _ in owners]}")
+
+    measurement = data.get("measurement")
+    if not isinstance(measurement, dict):
+        errors.append("measurement must be a mapping")
+    else:
+        engines = measurement.get("engines")
+        if not isinstance(engines, list) or not engines or any(not isinstance(engine, str) or not engine.strip() for engine in engines):
+            errors.append("measurement.engines must be a non-empty list of names")
+        if not str(measurement.get("cadence") or "").strip():
+            errors.append("measurement.cadence is required")
+
+    guardrails = data.get("guardrails")
+    required_guardrails = ("no_duplicate_query_owners", "no_auto_publish_visible_copy", "no_fabricated_proof", "require_fresh_crawl_before_verdict")
+    if not isinstance(guardrails, dict):
+        errors.append("guardrails must be a mapping")
+    else:
+        for key in required_guardrails:
+            if guardrails.get(key) is not True:
+                errors.append(f"guardrails.{key} must be true")
+    return errors
+
+
+def load_project_config(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    """Load and strictly validate optional ``project.yaml``.
+
+    ``None`` means the workspace is legacy and still uses config.yaml project
+    fields. An invalid file raises ``ProjectConfigError`` and never falls back.
+    """
+    path = project_config_path(home)
+    if not path.is_file():
+        return None
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:
+        raise ProjectConfigError(f"{path}: PyYAML is required to parse project.yaml") from exc
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise ProjectConfigError(f"{path}: cannot parse YAML: {exc}") from exc
+    errors = validate_project_config(data)
+    if errors:
+        raise ProjectConfigError(f"{path}: " + "; ".join(errors))
+    return data
+
+
+def project_summary(project: Optional[Dict[str, Any]], home: Optional[Path] = None) -> Dict[str, Any]:
+    """Return safe, machine-readable project status for doctor and run plans."""
+    if not project:
+        return {
+            "id": None,
+            "canonical_domain": None,
+            "config_source": "config.yaml (legacy fallback)",
+            "active_queries": 0,
+            "active_pages": 0,
+            "validated": False,
+        }
+    return {
+        "id": project["project"]["id"],
+        "canonical_domain": project["project"]["canonical_domain"],
+        "config_source": str(project_config_path(home)),
+        "active_queries": sum(1 for query in project.get("queries", []) if query.get("active", True)),
+        "active_pages": sum(1 for page in project.get("pages", []) if page.get("active", True)),
+        "validated": True,
+    }
+
+
+def project_inputs(project: Optional[Dict[str, Any]], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve project-specific collector inputs with explicit legacy fallback."""
+    if project:
+        active_queries = [query["text"] for query in project.get("queries", []) if query.get("active", True)]
+        active_pages = [page["url"] for page in project.get("pages", []) if page.get("active", True)]
+        return {
+            "queries": active_queries,
+            "urls": active_pages,
+            "target_domain": project["project"]["canonical_domain"],
+            "source": PROJECT_CONFIG_NAME,
+        }
+    return {
+        "queries": list(config_get(config, "collectors.serp.queries", []) or []),
+        "urls": list(config_get(config, "collectors.page.urls", []) or []),
+        "target_domain": str(config_get(config, "collectors.serp.target_domain", "") or ""),
+        "source": CONFIG_NAME + " (legacy fallback)",
+    }
 
 
 def load_config(home: Optional[Path] = None) -> Dict[str, Any]:

--- a/examples/project.yaml
+++ b/examples/project.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+project:
+  id: egeoagents
+  name: E-GEO
+  repository: https://github.com/mverab/eGEOagents
+  canonical_domain: egeoagents.com
+  canonical_url: https://egeoagents.com/
+  language: en
+
+queries:
+  - id: generic-geo-evaluation
+    text: GEO evaluation harness open source
+    class: generic
+    intent: evaluation
+    target_pages: [docs-evaluation]
+    active: true
+  - id: generic-llms-txt
+    text: what is llms.txt
+    class: informational
+    intent: llms-txt
+    target_pages: [concept-llms-txt]
+    active: true
+  - id: branded-egeo
+    text: E-GEO generative engine optimization toolkit
+    class: branded
+    intent: product
+    target_pages: [home]
+    active: true
+
+pages:
+  - id: home
+    url: https://egeoagents.com/
+    purpose: product
+    canonical: true
+    active: true
+  - id: docs-evaluation
+    url: https://egeoagents.com/docs/evaluation/
+    purpose: product-capability
+    canonical: true
+    active: true
+  - id: concept-llms-txt
+    url: https://egeoagents.com/concepts/what-is-llms-txt/
+    purpose: education
+    canonical: true
+    active: true
+
+measurement:
+  engines: [google-search-console, perplexity]
+  cadence: weekly
+
+# These are policy guardrails, not credentials or service configuration.
+guardrails:
+  no_duplicate_query_owners: true
+  no_auto_publish_visible_copy: true
+  no_fabricated_proof: true
+  require_fresh_crawl_before_verdict: true

--- a/openspec/changes/add-portable-project-config/design.md
+++ b/openspec/changes/add-portable-project-config/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`$EGEO_HOME/config.yaml` currently mixes loop machinery with project-specific collector inputs. `egeo loop run <domain>` also depends on a manually maintained domain charter. The reusable boundary should be explicit and inspectable before any agent interprets data.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Make one project portable by changing data, not Python code.
+  - Give every tracked query and URL an owner, purpose, and stable ID.
+  - Reject ambiguous query/page ownership before collection.
+  - Preserve existing workspaces and one-shot CLI behavior.
+  - Keep project state outside the public repository.
+- Non-goals:
+  - Automatically publish content or merge PRs.
+  - Replace the substrate, domain charters, or append-only collector data.
+  - Add a database, external service, or new paid API.
+  - Infer project configuration from the web at runtime.
+
+## Decisions
+
+### File boundary
+
+`$EGEO_HOME/project.yaml` is the active project's declarative contract. A separate `$EGEO_HOME` is the portability unit for each project. `config.yaml` remains the loop runtime contract.
+
+### Contract shape
+
+```yaml
+schema_version: 1
+project:
+  id: egeoagents
+  name: E-GEO
+  repository: https://github.com/mverab/eGEOagents
+  canonical_domain: egeoagents.com
+  canonical_url: https://egeoagents.com/
+  language: en
+
+queries:
+  - id: generic-geo-evaluation
+    text: GEO evaluation harness open source
+    class: generic
+    intent: evaluation
+    target_pages: [docs-evaluation]
+    active: true
+
+pages:
+  - id: docs-evaluation
+    url: https://egeoagents.com/docs/evaluation/
+    purpose: product-capability
+    canonical: true
+    active: true
+
+measurement:
+  engines: [google-search-console, perplexity]
+  cadence: weekly
+
+guardrails:
+  no_duplicate_query_owners: true
+  no_auto_publish_visible_copy: true
+  no_fabricated_proof: true
+  require_fresh_crawl_before_verdict: true
+```
+
+The implementation may add fields, but these fields and invariants are the stable v1 contract.
+
+### Precedence and migration
+
+- If `project.yaml` exists and validates, collectors read its `project.canonical_domain`, `queries`, and `pages`.
+- Explicit CLI flags remain highest precedence.
+- If no `project.yaml` exists, current `config.yaml` fields continue to work unchanged.
+- Doctor reports the compatibility fallback so a user knows the workspace is not yet portable.
+- Invalid `project.yaml` fails closed; it must not silently fall back to stale project data.
+
+### Validation
+
+Validation is deterministic and LLM-free. It checks schema version, required identity fields, URL/domain consistency, unique IDs, non-empty active query text, valid query classes, page references, and the anti-spam/canibalization guardrails. It never calls a search engine and never writes project artifacts.
+
+## Risks / Trade-offs
+
+- Two config files can confuse users during migration → doctor prints the active source and fallback status; docs show the boundary.
+- A project contract can become stale → every measurement record retains its query/page IDs and the loop reports stale active targets rather than inventing replacements.
+- A strict schema can block old workspaces → compatibility fallback remains until project.yaml is added; no automatic destructive migration.
+
+## Migration Plan
+
+1. Add loader, schema validator, and example fixture.
+2. Add project precedence to collectors and run-plan construction.
+3. Add doctor output and tests for legacy and portable workspaces.
+4. Migrate the E-GEO workspace by creating project.yaml outside the public repo.
+5. Run fixture collectors and a dry-run plan for E-GEO and a second fixture project.
+6. Only after verification, document `project.yaml` as the portability boundary.
+
+## Open Questions
+
+- None for v1. The second-project fixture can be synthetic and offline; it must not use credentials or claim live outcomes.

--- a/openspec/changes/add-portable-project-config/proposal.md
+++ b/openspec/changes/add-portable-project-config/proposal.md
@@ -1,0 +1,21 @@
+# Change: Add a portable project contract for loop runs
+
+## Why
+
+The loop already separates state into `$EGEO_HOME`, but project identity, canonical targets, tracked queries, and page ownership still live in a machinery-oriented `config.yaml` or in manual domain charters. That makes the loop bespoke: adopting it for another project requires editing collector code or rediscovering the same inputs by hand.
+
+## What Changes
+
+- Add an additive `$EGEO_HOME/project.yaml` contract for one active project/workspace.
+- Keep `config.yaml` responsible for loop machinery: cadence, models, budgets, reflection, and scheduler-facing settings.
+- Move project facts into `project.yaml`: project identity, canonical domain, tracked pages, query records, source/measurement settings, and anti-spam/canibalization guardrails.
+- Add deterministic loading and validation before collectors or run plans consume project inputs.
+- Keep CLI compatibility: existing `config.yaml` collector fields remain accepted during migration; project.yaml takes precedence when present.
+- Add an example project file and a portability test that runs the same code with a second project fixture without code edits.
+
+## Impact
+
+- Affected capability: `geo-loop-runtime` and collector configuration.
+- Affected code: `egeo/workspace.py`, `egeo/loop.py`, collectors, docs, tests.
+- No credentials, API keys, or private Search Console data enter the repository or project contract.
+- No visible copy, auto-publish, auto-merge, or payment behavior changes.

--- a/openspec/changes/add-portable-project-config/specs/geo-loop-runtime/spec.md
+++ b/openspec/changes/add-portable-project-config/specs/geo-loop-runtime/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Active Project Has a Declarative Contract
+
+A bootstrapped loop workspace MAY contain `$EGEO_HOME/project.yaml`. When present, it SHALL define one active project's identity, canonical URL/domain, tracked query records, tracked page records, measurement settings, and anti-spam/canibalization guardrails. The contract SHALL be versioned and contain no credentials or private tokens.
+
+#### Scenario: Portable project fixture
+
+- **WHEN** the same loop code is pointed at a second workspace containing a valid `project.yaml`
+- **THEN** the run plan and fixture collectors use that project's identity, domain, queries, and pages
+- **AND** no Python source edit is required
+
+#### Scenario: Contract contains a secret
+
+- **WHEN** `project.yaml` contains a credential-like key or secret value
+- **THEN** validation fails with a remediation message
+- **AND** no collector record or LOG line is written
+
+### Requirement: Project Contract Is Validated Before Use
+
+The system SHALL validate `project.yaml` deterministically before any collector or run plan consumes project-specific inputs. Validation SHALL reject unsupported schema versions, duplicate IDs, URL/domain mismatches, orphan page references, empty active queries, and conflicting canonical ownership.
+
+#### Scenario: Invalid contract
+
+- **WHEN** an active workspace has invalid `project.yaml`
+- **THEN** `egeo loop doctor` reports the exact field and violation
+- **AND** `egeo loop collect` exits non-zero without appending JSONL or LOG data
+
+#### Scenario: Anti-cannibalization ownership
+
+- **WHEN** two active query records claim the same canonical page for the same intent without an explicit experiment relationship
+- **THEN** validation rejects the contract
+- **AND** names the conflicting query and page IDs
+
+### Requirement: Project Configuration Is Separate From Loop Machinery
+
+`project.yaml` SHALL hold project identity and measurement targets; `config.yaml` SHALL hold cadence, models, budgets, reflection, and scheduler-facing machinery. When a valid `project.yaml` exists, its project-specific values SHALL take precedence over legacy collector values in `config.yaml`. Explicit CLI flags SHALL take precedence over both.
+
+#### Scenario: Valid project file takes precedence
+
+- **WHEN** `project.yaml` and `config.yaml` specify different target domains or query lists
+- **THEN** the collector uses `project.yaml` values
+- **AND** `egeo loop doctor` reports `project.yaml` as the active source
+
+#### Scenario: Legacy workspace remains runnable
+
+- **WHEN** no `project.yaml` exists but legacy `config.yaml` contains collector inputs
+- **THEN** current commands continue to work unchanged
+- **AND** doctor reports that compatibility fallback is active
+
+### Requirement: Project Source Is Observable
+
+`egeo loop doctor` and `egeo loop run --json` SHALL report the active project ID, canonical domain, project configuration source, validation status, and counts of active queries and pages. They SHALL never print secret values.
+
+#### Scenario: Operator checks portability
+
+- **WHEN** an operator runs doctor on a valid portable workspace
+- **THEN** the output identifies the project contract and active target counts
+- **AND** the output is sufficient to reproduce the setup in another workspace without reading Python code

--- a/openspec/changes/add-portable-project-config/tasks.md
+++ b/openspec/changes/add-portable-project-config/tasks.md
@@ -1,0 +1,26 @@
+## 1. Contract and loader
+
+- [x] 1.1 Add the v1 `project.yaml` schema contract and example fixture.
+- [x] 1.2 Implement workspace project loading with strict validation and clear errors.
+- [x] 1.3 Keep `config.yaml` machinery separate from project inputs.
+
+## 2. Runtime integration
+
+- [x] 2.1 Make SERP collector resolve active queries and canonical domain from project.yaml when present.
+- [x] 2.2 Make page collector resolve active tracked pages from project.yaml when present.
+- [x] 2.3 Include project identity and configuration source in `egeo loop run --json` and `egeo loop doctor`.
+- [x] 2.4 Preserve explicit CLI overrides and legacy config fallback.
+
+## 3. Enforcement and portability tests
+
+- [x] 3.1 Reject duplicate query IDs, duplicate canonical owners, orphan page references, and mixed branded/generic ownership.
+- [x] 3.2 Add offline fixture tests for E-GEO-shaped and second-project-shaped configurations.
+- [x] 3.3 Verify invalid project.yaml fails closed without writing JSONL or LOG entries.
+- [x] 3.4 Verify one-shot commands remain unaffected when no workspace exists.
+
+## 4. Documentation and verification
+
+- [x] 4.1 Document the project.yaml/config.yaml boundary and migration path.
+- [x] 4.2 Run `openspec validate add-portable-project-config --strict`.
+- [x] 4.3 Run the full Python test/quality suite and fixture collector passes.
+- [x] 4.4 Run two dry-run plans with the same code and different project fixtures.

--- a/site/src/content/docs/docs/geo-loop.md
+++ b/site/src/content/docs/docs/geo-loop.md
@@ -26,6 +26,7 @@ All loop state lives **outside the repo**, in the workspace resolved from `$EGEO
 $EGEO_HOME/
 ├── LOG.md                        # append-only activity feed (one line per event)
 ├── config.yaml                   # cadence, models, budgets, scaling weights
+├── project.yaml                  # project identity, targets, guardrails (optional migration)
 ├── SUBSTRATE.md                  # the contract, vendored on bootstrap
 ├── signals/<slug>.md             # evidence — deduped, frequency-counted
 ├── docs/<slug>.md                # durable knowledge — analyses, decisions
@@ -35,6 +36,19 @@ $EGEO_HOME/
 ```
 
 The layout and artifact rules are defined by `SUBSTRATE.md` and mechanically enforced by `python -m egeo.substrate_lint`.
+
+### Portable project contract
+
+`project.yaml` is the portability boundary. It describes the active project's
+canonical domain, tracked queries, tracked pages, measurement engines, and
+anti-spam/canibalization guardrails. `config.yaml` remains the loop machinery
+(cadence, models, budgets, and reflection). When `project.yaml` exists, it is
+validated before collection and takes precedence over legacy project fields in
+`config.yaml`; explicit CLI flags still win. If it is absent, the legacy
+configuration remains runnable and `egeo loop doctor` reports the fallback.
+
+Copy the shape from [`examples/project.yaml`](https://github.com/mverab/eGEOagents/blob/main/examples/project.yaml).
+The contract contains no API keys, OAuth tokens, or private Search Console data.
 
 ## Commands
 

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,76 @@
+"""Tests for the portable project contract and legacy fallback."""
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from egeo import workspace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "project.yaml"
+
+
+class ProjectConfigTests(unittest.TestCase):
+    def _workspace(self) -> Path:
+        home = Path(tempfile.mkdtemp(prefix="egeo-project-test-"))
+        shutil.copy(EXAMPLE, home / workspace.PROJECT_CONFIG_NAME)
+        return home
+
+    def test_example_contract_loads_and_summarizes(self) -> None:
+        home = self._workspace()
+        try:
+            project = workspace.load_project_config(home)
+            self.assertIsNotNone(project)
+            summary = workspace.project_summary(project, home)
+            self.assertEqual(summary["id"], "egeoagents")
+            self.assertEqual(summary["active_queries"], 3)
+            self.assertEqual(summary["active_pages"], 3)
+            self.assertTrue(summary["validated"])
+        finally:
+            shutil.rmtree(home)
+
+    def test_same_code_accepts_a_second_project_fixture(self) -> None:
+        home = self._workspace()
+        try:
+            text = (home / workspace.PROJECT_CONFIG_NAME).read_text(encoding="utf-8")
+            text = text.replace("egeoagents", "second-project").replace("E-GEO", "Second Project")
+            text = text.replace("github.com/mverab/eGEOagents", "github.com/example/second-project")
+            text = text.replace("second-project.com", "second.example.com")
+            (home / workspace.PROJECT_CONFIG_NAME).write_text(text, encoding="utf-8")
+            project = workspace.load_project_config(home)
+            inputs = workspace.project_inputs(project, {"collectors": {"serp": {"queries": ["stale"]}}})
+            self.assertEqual(inputs["source"], "project.yaml")
+            self.assertEqual(inputs["target_domain"], "second.example.com")
+            self.assertNotIn("stale", inputs["queries"])
+        finally:
+            shutil.rmtree(home)
+
+    def test_legacy_config_fallback_is_explicit(self) -> None:
+        home = Path(tempfile.mkdtemp(prefix="egeo-legacy-test-"))
+        try:
+            config = {"collectors": {"serp": {"queries": ["legacy query"], "target_domain": "legacy.example"}, "page": {"urls": ["https://legacy.example/"]}}}
+            inputs = workspace.project_inputs(None, config)
+            self.assertEqual(inputs["source"], "config.yaml (legacy fallback)")
+            self.assertEqual(inputs["queries"], ["legacy query"])
+            self.assertEqual(inputs["target_domain"], "legacy.example")
+        finally:
+            shutil.rmtree(home)
+
+    def test_secret_key_is_rejected_without_echoing_value(self) -> None:
+        project = {"schema_version": 1, "project": {"id": "safe", "name": "Safe", "repository": "https://github.com/example/safe", "canonical_domain": "safe.example", "canonical_url": "https://safe.example/", "language": "en"}, "api_key": "DO_NOT_PRINT", "pages": [], "queries": [], "measurement": {"engines": ["test"], "cadence": "weekly"}, "guardrails": {"no_duplicate_query_owners": True, "no_auto_publish_visible_copy": True, "no_fabricated_proof": True, "require_fresh_crawl_before_verdict": True}}
+        errors = workspace.validate_project_config(project)
+        rendered = " ".join(errors)
+        self.assertIn("api_key", rendered)
+        self.assertNotIn("DO_NOT_PRINT", rendered)
+
+    def test_same_intent_cannot_have_two_canonical_owners(self) -> None:
+        project = {"schema_version": 1, "project": {"id": "safe", "name": "Safe", "repository": "https://github.com/example/safe", "canonical_domain": "safe.example", "canonical_url": "https://safe.example/", "language": "en"}, "pages": [{"id": "page", "url": "https://safe.example/page", "active": True}], "queries": [{"id": "one", "text": "same", "class": "generic", "intent": "same", "target_pages": ["page"], "active": True}, {"id": "two", "text": "another", "class": "generic", "intent": "same", "target_pages": ["page"], "active": True}], "measurement": {"engines": ["test"], "cadence": "weekly"}, "guardrails": {"no_duplicate_query_owners": True, "no_auto_publish_visible_copy": True, "no_fabricated_proof": True, "require_fresh_crawl_before_verdict": True}}
+        errors = workspace.validate_project_config(project)
+        self.assertTrue(any("canonical ownership collision" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
Adds the reusable `project.yaml` boundary for loop workspaces. It separates project identity/queries/pages/measurement/guardrails from runtime machinery in `config.yaml`.

## Enforcement
- strict deterministic validation before collectors/run plans
- rejects credential-like keys, duplicate IDs, orphan page references, domain/URL mismatches, and query/page ownership collisions
- explicit CLI flags > project.yaml > legacy config.yaml
- invalid contracts fail closed
- one-shot mode remains workspace-free

## Verification
- 5 unit tests green
- offline SERP + page collectors consumed project.yaml (3 queries + 3 pages) with no API keys
- invalid contract: rc=1, 0 JSONL, no collector LOG line
- second project fixture accepted without source edits
- OpenSpec strict validation green
- site build + verify.sh green

## Real workspace
Migrated the persistent SlashStack PoC workspace at `$EGEO_HOME` with a private, credential-free `project.yaml`; existing config, JSONL history, and crons were preserved.

## Gate
PR intentionally not merged or deployed yet.