### PR TITLE
feat(loop): add deterministic decide command

### DIFF
--- a/.claude/skills/geo-loop/SKILL.md
+++ b/.claude/skills/geo-loop/SKILL.md
@@ -48,6 +48,7 @@ not in a runnable state (`egeo loop doctor` explains why).
 - `$EGEO_HOME/signals/` and `$EGEO_HOME/docs/` — what is already known, so you
   dedupe instead of duplicating.
 - `$EGEO_HOME/config.yaml` — models, budgets, `reflect.auto_apply`.
+- `$EGEO_HOME/data/outcomes/ledger.jsonl` — append-only decision outcomes when `egeo loop decide` has run.
 
 ### 3. Do the work
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ See [`examples/project.yaml`](examples/project.yaml) for the portable contract.
 | Command | What it does |
 |---------|--------------|
 | `egeo loop doctor` | Bootstrap the workspace if missing, then health-check it (layout, config, budgets, substrate lint) |
+| `egeo loop decide` | Rank exactly one next action from collector JSONL + the outcome ledger (LLM-free; never publishes) |
 | `egeo loop collect serp` | Record a search-result snapshot (Brave API) into `data/serp/*.jsonl` |
 | `egeo loop collect page` | Record a page snapshot (hash, title, meta, JSON-LD types, word count) into `data/page/*.jsonl` |
 | `egeo loop run <domain>` | Resolve and print the run plan — current focus, fresh collector deltas, candidate signals |

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,7 +4,8 @@
 - `geo_eval.py`: evaluation + lightweight prompt meta-optimization
 - `llm_client.py`: OpenAI-compatible HTTP client (stdlib only)
 - `prompts/`: prompt templates
-- `egeo/loop.py`: loop-mode CLI (`egeo loop run|collect|doctor`)
+- `egeo/loop.py`: loop-mode CLI (`egeo loop run|collect|doctor|decide`)
+- `egeo/decide.py`: deterministic next-action ranking + outcome ledger
 - `egeo/workspace.py`: `$EGEO_HOME` resolution + substrate bootstrap
 - `collectors/`: deterministic collectors (`serp`, `page`) and their fixtures
 
@@ -73,6 +74,9 @@ egeo loop collect page --url https://example.com/pricing \
 
 # Print the run plan for a domain — writes nothing
 egeo loop run example-com --dry-run
+
+# Rank one next action from collector JSONL + the outcome ledger — writes nothing
+egeo loop decide --dry-run
 
 # Execute one bounded iteration (the agent does the interpretive work)
 claude -p "/geo:loop example-com"

--- a/egeo/decide.py
+++ b/egeo/decide.py
@@ -1,0 +1,434 @@
+"""Deterministic loop decision layer: rank one next action, never apply.
+
+LLM-free. Reads project.yaml, collector JSONL, and an append-only outcome
+ledger. Writes at most one proposed ledger row, one proposal doc, and one
+LOG.md line. Never publishes, merges, or sets status ``applied``.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import workspace
+
+LEDGER_REL = Path("data") / "outcomes" / "ledger.jsonl"
+SCHEMA_VERSION = 1
+WINDOWS_DAYS = (7, 14, 28)
+OPEN_STATUSES = {"proposed", "applied"}
+OWNER_KINDS = {"escalate_absent", "propose_page_owner", "propose_schema"}
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def ledger_path(home: Path) -> Path:
+    return home / LEDGER_REL
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    text = str(value).replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _slug(value: str) -> str:
+    return _SLUG_RE.sub("-", value.lower()).strip("-") or "item"
+
+
+def read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.is_file():
+        return []
+    records: List[Dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            records.append(item)
+    return records
+
+
+def append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def load_ledger(home: Path) -> List[Dict[str, Any]]:
+    return read_jsonl(ledger_path(home))
+
+
+def _stream_slug(value: str, max_length: int = 60) -> str:
+    value = re.sub(r"^https?://", "", value.strip().lower())
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return (value[:max_length].rstrip("-") or "untitled")
+
+
+def _query_stream(home: Path, text: str) -> Path:
+    return workspace.data_dir("serp", home) / f"{_stream_slug(text)}.jsonl"
+
+
+def _page_stream(home: Path, url: str) -> Path:
+    return workspace.data_dir("page", home) / f"{_stream_slug(url)}.jsonl"
+
+
+def _cadence_days(project: Dict[str, Any]) -> int:
+    raw = str((project.get("measurement") or {}).get("cadence") or "weekly").lower()
+    if raw.startswith("day") or raw == "daily":
+        return 1
+    if raw.startswith("month"):
+        return 30
+    return 7
+
+
+def _key(kind: str, query_ids: List[str], page_ids: List[str]) -> Tuple[str, Tuple[str, ...], Tuple[str, ...]]:
+    return (kind, tuple(query_ids), tuple(page_ids))
+
+
+def _open_keys(ledger: List[Dict[str, Any]]) -> set:
+    return {
+        _key(str(row.get("kind") or ""), list(row.get("query_ids") or []), list(row.get("page_ids") or []))
+        for row in ledger
+        if row.get("status") in OPEN_STATUSES
+    }
+
+
+def _action(
+    *,
+    kind: str,
+    reason: str,
+    next_gate: str,
+    query_ids: Optional[List[str]] = None,
+    page_ids: Optional[List[str]] = None,
+    evidence: Optional[List[str]] = None,
+    grade: Optional[str] = None,
+    ledger_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "kind": kind,
+        "reason": reason,
+        "next_gate": next_gate,
+        "query_ids": query_ids or [],
+        "page_ids": page_ids or [],
+        "evidence": evidence or [],
+        "grade": grade,
+        "ledger_id": ledger_id,
+        "auto_apply": False,
+    }
+
+
+def rank_action(home: Path, project: Dict[str, Any], now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Return exactly one ranked action. Pure read except path resolution."""
+    now = now or _now()
+    ledger = load_ledger(home)
+    open_keys = _open_keys(ledger)
+    cadence = _cadence_days(project)
+    queries = [q for q in project.get("queries", []) if q.get("active", True)]
+    pages = [p for p in project.get("pages", []) if p.get("active", True)]
+    page_by_id = {p["id"]: p for p in pages}
+
+    # 1. collect_fresh
+    newest: List[datetime] = []
+    any_stream = False
+    for query in queries:
+        records = read_jsonl(_query_stream(home, query["text"]))
+        if records:
+            any_stream = True
+            ts = _parse_ts(records[-1].get("ts"))
+            if ts:
+                newest.append(ts)
+    for page in pages:
+        records = read_jsonl(_page_stream(home, page["url"]))
+        if records:
+            any_stream = True
+            ts = _parse_ts(records[-1].get("ts"))
+            if ts:
+                newest.append(ts)
+    if not any_stream or (newest and (now - max(newest)) > timedelta(days=cadence)):
+        return _action(
+            kind="collect_fresh",
+            reason="no collector observations" if not any_stream else f"last observation older than {cadence}d cadence",
+            next_gate="scheduler",
+        )
+
+    # 2/3. wait_for_window or grade_outcome
+    for row in ledger:
+        if row.get("status") not in OPEN_STATUSES:
+            continue
+        created = _parse_ts(row.get("ts"))
+        if not created:
+            continue
+        age_days = (now - created).days
+        grades = row.get("grades") or {}
+        pending = [d for d in WINDOWS_DAYS if age_days >= d and str(d) not in {str(k) for k in grades}]
+        if not pending:
+            if age_days < WINDOWS_DAYS[0]:
+                return _action(
+                    kind="wait_for_window",
+                    reason=f"open {row.get('kind')} {row.get('id')} waiting for day {WINDOWS_DAYS[0]}",
+                    next_gate="none",
+                    query_ids=list(row.get("query_ids") or []),
+                    page_ids=list(row.get("page_ids") or []),
+                    ledger_id=str(row.get("id")),
+                )
+            continue
+        window = pending[0]
+        grade, evidence = _grade_row(home, project, row, created)
+        if grade is None:
+            return _action(
+                kind="wait_for_window",
+                reason=f"window {window}d reached but no later observations for {row.get('id')}",
+                next_gate="scheduler",
+                query_ids=list(row.get("query_ids") or []),
+                page_ids=list(row.get("page_ids") or []),
+                ledger_id=str(row.get("id")),
+            )
+        return _action(
+            kind="grade_outcome",
+            reason=f"window {window}d grade={grade} for {row.get('id')}",
+            next_gate="none",
+            query_ids=list(row.get("query_ids") or []),
+            page_ids=list(row.get("page_ids") or []),
+            evidence=evidence,
+            grade=grade,
+            ledger_id=str(row.get("id")),
+        )
+
+    # 4. escalate_absent
+    for query in queries:
+        stream = _query_stream(home, query["text"])
+        records = read_jsonl(stream)
+        if len(records) < 3:
+            continue
+        if all(r.get("target_position") is None for r in records[-3:]):
+            key = _key("escalate_absent", [query["id"]], list(query.get("target_pages") or []))
+            if key in open_keys:
+                continue
+            rel = str(stream.relative_to(home)) if stream.is_relative_to(home) else str(stream)
+            return _action(
+                kind="escalate_absent",
+                reason=f"query {query['id']!r} absent from top 10 in last 3 observations",
+                next_gate="owner",
+                query_ids=[query["id"]],
+                page_ids=list(query.get("target_pages") or []),
+                evidence=[rel],
+            )
+
+    # 5. propose_page_owner
+    for query in queries:
+        if str(query.get("class") or "") not in {"generic", "informational"}:
+            continue
+        targets = [tid for tid in (query.get("target_pages") or []) if tid in page_by_id]
+        if targets:
+            continue
+        key = _key("propose_page_owner", [query["id"]], [])
+        if key in open_keys:
+            continue
+        return _action(
+            kind="propose_page_owner",
+            reason=f"query {query['id']!r} has no canonical target page",
+            next_gate="owner",
+            query_ids=[query["id"]],
+        )
+
+    # 6. propose_schema
+    for page in pages:
+        stream = _page_stream(home, page["url"])
+        records = read_jsonl(stream)
+        if not records:
+            continue
+        types = records[-1].get("jsonld_types") or []
+        if types:
+            continue
+        key = _key("propose_schema", [], [page["id"]])
+        if key in open_keys:
+            continue
+        rel = str(stream.relative_to(home)) if stream.is_relative_to(home) else str(stream)
+        return _action(
+            kind="propose_schema",
+            reason=f"page {page['id']!r} has empty jsonld_types",
+            next_gate="owner",
+            page_ids=[page["id"]],
+            evidence=[rel],
+        )
+
+    return _action(kind="no_op", reason="no deterministic action", next_gate="none")
+
+
+def _grade_row(home: Path, project: Dict[str, Any], row: Dict[str, Any], created: datetime) -> Tuple[Optional[str], List[str]]:
+    kind = row.get("kind")
+    evidence: List[str] = []
+    later = False
+    if kind == "escalate_absent":
+        query_ids = set(row.get("query_ids") or [])
+        for query in project.get("queries", []):
+            if query.get("id") not in query_ids:
+                continue
+            stream = _query_stream(home, query["text"])
+            records = read_jsonl(stream)
+            after = [r for r in records if (_parse_ts(r.get("ts")) or created) > created]
+            if not after:
+                continue
+            later = True
+            rel = str(stream.relative_to(home)) if stream.is_relative_to(home) else str(stream)
+            evidence.append(rel)
+            if any(r.get("target_position") is not None for r in after):
+                return "verified", evidence
+        return ("unchanged" if later else None), evidence
+    if kind == "propose_schema":
+        page_ids = set(row.get("page_ids") or [])
+        pages = {p["id"]: p for p in project.get("pages", [])}
+        for page_id in page_ids:
+            page = pages.get(page_id)
+            if not page:
+                continue
+            stream = _page_stream(home, page["url"])
+            records = read_jsonl(stream)
+            after = [r for r in records if (_parse_ts(r.get("ts")) or created) > created]
+            if not after:
+                continue
+            later = True
+            rel = str(stream.relative_to(home)) if stream.is_relative_to(home) else str(stream)
+            evidence.append(rel)
+            if after[-1].get("jsonld_types"):
+                return "verified", evidence
+        return ("unchanged" if later else None), evidence
+    return (None, evidence)
+
+
+def _proposal_markdown(action: Dict[str, Any], project: Dict[str, Any]) -> str:
+    ident = project["project"]["id"]
+    lines = [
+        f"# Decision proposal: {action['kind']}",
+        "",
+        f"- project: `{ident}`",
+        f"- kind: `{action['kind']}`",
+        f"- next_gate: `{action['next_gate']}`",
+        f"- auto_apply: `false`",
+        f"- query_ids: {', '.join(action['query_ids']) or '—'}",
+        f"- page_ids: {', '.join(action['page_ids']) or '—'}",
+        "",
+        "## Reason",
+        "",
+        action["reason"],
+        "",
+        "## Evidence",
+        "",
+    ]
+    if action["evidence"]:
+        lines.extend(f"- `{path}`" for path in action["evidence"])
+    else:
+        lines.append("- (none)")
+    lines.extend(
+        [
+            "",
+            "## Gate",
+            "",
+            "Owner must approve before any site edit, PR, merge, or deploy.",
+            "Visible copy, prices, and CTAs are never auto-published.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def apply_decision(home: Path, project: Dict[str, Any], action: Dict[str, Any], now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Persist the ranked action. Never sets status=applied."""
+    now = now or _now()
+    result = dict(action)
+    result["written"] = []
+    stamp = now.strftime("%Y-%m-%dT%H:%MZ")
+    if action["kind"] == "no_op":
+        line = workspace.append_log("egeo-core", "decide", "no deterministic action, outcome=no-op", home=home)
+        result["written"].append("LOG.md")
+        result["log"] = line
+        return result
+    if action["kind"] == "wait_for_window":
+        line = workspace.append_log(
+            "egeo-core",
+            "decide",
+            f"{action['kind']}: {action['reason']}, outcome=no-op",
+            home=home,
+        )
+        result["written"].append("LOG.md")
+        result["log"] = line
+        return result
+    if action["kind"] == "grade_outcome":
+        row = {
+            "v": SCHEMA_VERSION,
+            "id": f"{stamp}-grade-{_slug(action.get('ledger_id') or 'row')}",
+            "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "project_id": project["project"]["id"],
+            "kind": "grade_outcome",
+            "status": action.get("grade") or "unchanged",
+            "query_ids": action["query_ids"],
+            "page_ids": action["page_ids"],
+            "evidence": action["evidence"],
+            "windows_days": list(WINDOWS_DAYS),
+            "grades": {},
+            "next_gate": "none",
+            "auto_apply": False,
+            "graded_id": action.get("ledger_id"),
+        }
+        append_jsonl(ledger_path(home), row)
+        line = workspace.append_log(
+            "egeo-core",
+            "decide",
+            f"graded {action.get('ledger_id')} as {row['status']}, outcome=success",
+            home=home,
+        )
+        result["written"].extend([str(LEDGER_REL), "LOG.md"])
+        result["log"] = line
+        result["ledger_row"] = row
+        return result
+
+    slug = _slug("-".join([action["kind"], *(action["query_ids"] or action["page_ids"] or ["item"])]))
+    row = {
+        "v": SCHEMA_VERSION,
+        "id": f"{stamp}-{slug}",
+        "ts": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "project_id": project["project"]["id"],
+        "kind": action["kind"],
+        "status": "proposed",
+        "query_ids": action["query_ids"],
+        "page_ids": action["page_ids"],
+        "evidence": action["evidence"],
+        "windows_days": list(WINDOWS_DAYS),
+        "grades": {},
+        "next_gate": action["next_gate"],
+        "auto_apply": False,
+    }
+    append_jsonl(ledger_path(home), row)
+    result["written"].append(str(LEDGER_REL))
+    result["ledger_row"] = row
+    if action["kind"] in OWNER_KINDS:
+        doc_name = f"{now.strftime('%Y-%m-%d')}-decide-{slug}.md"
+        doc_path = home / "docs" / doc_name
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text(_proposal_markdown(action, project), encoding="utf-8")
+        result["written"].append(f"docs/{doc_name}")
+        result["proposal"] = str(doc_path)
+    line = workspace.append_log(
+        "egeo-core",
+        "decide",
+        f"{action['kind']} proposed ({row['id']}), outcome=success",
+        home=home,
+    )
+    result["written"].append("LOG.md")
+    result["log"] = line
+    return result

--- a/egeo/loop.py
+++ b/egeo/loop.py
@@ -1,4 +1,4 @@
-"""``egeo loop`` — the loop-mode surface: ``run``, ``collect``, ``doctor``.
+"""``egeo loop`` — the loop-mode surface: ``run``, ``collect``, ``doctor``, ``decide``.
 
 Loop mode turns one-shot GEO into a continuous one: deterministic collectors
 record ground truth into a per-user workspace (``$EGEO_HOME``), and an agent run
@@ -15,6 +15,8 @@ design:
   ``.claude/skills/geo-loop/SKILL.md`` (in Claude Code: ``/geo:loop <domain>``,
   headless: ``claude -p "/geo:loop <domain>"``).
 - ``egeo loop doctor`` self-checks the workspace.
+- ``egeo loop decide`` ranks exactly one next action from collector JSONL and
+  the outcome ledger. It never publishes or merges.
 
 Any scheduler drives these commands identically; Hermes cron is the reference.
 """
@@ -403,6 +405,54 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_decide(args: argparse.Namespace) -> int:
+    from . import decide
+
+    home = workspace.resolve_home()
+    if args.dry_run:
+        if not workspace.exists(home):
+            print(
+                f"egeo loop decide: {home} is not bootstrapped yet (dry run writes nothing).\n"
+                "Run `egeo loop doctor` to create the workspace.",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        workspace.bootstrap(home)
+    try:
+        project = workspace.load_project_config(home)
+    except workspace.ProjectConfigError as exc:
+        print(f"egeo loop decide: invalid project contract: {exc}", file=sys.stderr)
+        return 1
+    if project is None:
+        print(
+            "egeo loop decide: project.yaml is required. Copy examples/project.yaml "
+            "into $EGEO_HOME and fill the active project's identity and targets.",
+            file=sys.stderr,
+        )
+        return 1
+    action = decide.rank_action(home, project)
+    payload: Dict[str, Any] = {"action": action, "dry_run": bool(args.dry_run), "workspace": str(home)}
+    if not args.dry_run:
+        payload.update(decide.apply_decision(home, project, action))
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+    else:
+        print(f"egeo loop decide: {action['kind']} ({'DRY RUN' if args.dry_run else 'recorded'})")
+        print(f"  reason:    {action['reason']}")
+        print(f"  next_gate: {action['next_gate']}")
+        print(f"  auto_apply: {action['auto_apply']}")
+        if action.get("query_ids"):
+            print(f"  queries:   {', '.join(action['query_ids'])}")
+        if action.get("page_ids"):
+            print(f"  pages:     {', '.join(action['page_ids'])}")
+        if action.get("evidence"):
+            print(f"  evidence:  {', '.join(action['evidence'])}")
+        if payload.get("written"):
+            print(f"  wrote:     {', '.join(payload['written'])}")
+    return 0
+
+
 # --------------------------------------------------------------------------- #
 # parser
 # --------------------------------------------------------------------------- #
@@ -410,12 +460,13 @@ def add_parser(sub: argparse._SubParsersAction) -> None:
     """Register the ``loop`` subcommand group on the ``egeo`` parser."""
     parser = sub.add_parser(
         "loop",
-        help="Loop mode: collectors, run plans, and workspace health ($EGEO_HOME).",
+        help="Loop mode: collectors, run plans, workspace health, and decisions ($EGEO_HOME).",
         description=(
             "Loop mode keeps state in a per-user workspace ($EGEO_HOME, default ~/.egeo). "
             "These commands are the scheduler seam and make zero LLM calls: `collect` gathers "
             "ground truth, `run` resolves the plan for one unit of work, `doctor` checks the "
-            "workspace. The interpretive loop run itself is executed by an agent runtime via "
+            "workspace, `decide` ranks one next action from collector data and the outcome ledger. "
+            "The interpretive loop run itself is executed by an agent runtime via "
             ".claude/skills/geo-loop/SKILL.md (`/geo:loop <domain>`)."
         ),
     )
@@ -461,10 +512,23 @@ def add_parser(sub: argparse._SubParsersAction) -> None:
     doctor.add_argument("--json", action="store_true", help="Print the diagnosis as JSON.")
     doctor.set_defaults(loop_handler=cmd_doctor)
 
+    decide_p = loop_sub.add_parser(
+        "decide",
+        help="Rank exactly one next action from collector data and the outcome ledger (no LLM, never publishes).",
+        description=(
+            "Reads project.yaml, collector JSONL, and data/outcomes/ledger.jsonl, then ranks one "
+            "action. Without --dry-run it may append one ledger row, one proposal doc, and one LOG "
+            "line. It never sets status=applied, never edits the site, and never opens a PR."
+        ),
+    )
+    decide_p.add_argument("--dry-run", action="store_true", help="Print the ranked action and write nothing.")
+    decide_p.add_argument("--json", action="store_true", help="Print the decision as JSON.")
+    decide_p.set_defaults(loop_handler=cmd_decide)
+
 
 def main(args: argparse.Namespace) -> int:
     """Dispatch a parsed ``egeo loop ...`` namespace."""
     return int(args.loop_handler(args))
 
 
-__all__ = ["add_parser", "main", "build_plan", "diagnose", "load_collector", "parse_charter"]
+__all__ = ["add_parser", "main", "build_plan", "diagnose", "load_collector", "parse_charter", "cmd_decide"]

--- a/openspec/changes/add-loop-decision-layer/design.md
+++ b/openspec/changes/add-loop-decision-layer/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`egeo loop run` currently prints candidate signals. The agent still has to invent the next action. Self-enforcing requires a deterministic decision function and a durable outcome record.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Rank exactly one next action per wake-up.
+  - Persist proposed/applied/verified/withdrawn outcomes with 7/14/28-day windows.
+  - Fail closed when project.yaml is invalid.
+  - Keep the command LLM-free.
+- Non-goals:
+  - Auto-publishing visible copy.
+  - Auto-merging PRs.
+  - Calling answer engines or Search Console from this command.
+  - Replacing collectors or the geo-loop skill.
+
+## Decisions
+
+### Command
+
+`egeo loop decide` is the scheduler seam for decisions. It reads:
+
+1. validated `project.yaml` (required; legacy config is not enough for ranking)
+2. collector JSONL under `$EGEO_HOME/data/`
+3. `$EGEO_HOME/data/outcomes/ledger.jsonl`
+
+It writes at most:
+
+- one new ledger row (`status: proposed`)
+- one proposal markdown under `$EGEO_HOME/docs/`
+- one LOG.md line
+
+`--dry-run` writes nothing.
+
+### Action kinds (fixed v1)
+
+| kind | trigger | next_gate |
+|---|---|---|
+| `collect_fresh` | no collector records, or last observation older than measurement cadence | run collectors |
+| `wait_for_window` | a proposed/applied action has not reached its next window | do nothing; grade later |
+| `grade_outcome` | an open ledger row has reached 7/14/28 days and new observations exist | mark improved / unchanged / worse / withdrawn |
+| `escalate_absent` | active query target_position is null across ≥3 observations | owner: indexing / discovery, not more pages |
+| `propose_page_owner` | active generic/informational query has no target_pages | owner: assign or create one canonical page |
+| `propose_schema` | tracked page has empty `jsonld_types` | owner: additive JSON-LD only |
+| `no_op` | none of the above | record no-op |
+
+Priority is the table order. Exactly one action is emitted.
+
+### Ledger record
+
+```json
+{
+  "v": 1,
+  "id": "2026-08-25T06:00Z-escalate-absent-slashstack",
+  "ts": "2026-08-25T06:00:00Z",
+  "project_id": "slashstack",
+  "kind": "escalate_absent",
+  "status": "proposed",
+  "query_ids": ["branded-slashstack"],
+  "page_ids": ["home"],
+  "evidence": ["data/serp/slashstack.jsonl"],
+  "windows_days": [7, 14, 28],
+  "grades": {},
+  "next_gate": "owner",
+  "auto_apply": false
+}
+```
+
+Statuses: `proposed` → `applied` (human) → `verified` | `unchanged` | `worse` | `withdrawn`.
+`decide` may set `verified/unchanged/worse/withdrawn` when grading from collector data. It never sets `applied`.
+
+### Proposal document
+
+Written only for kinds that need owner work (`escalate_absent`, `propose_page_owner`, `propose_schema`). Body cites evidence paths, names the gate, and states `auto_apply: false`.
+
+## Risks / Trade-offs
+
+- Ranking too aggressively creates spammy docs → one action per wake-up, dedupe against open ledger rows of the same kind+query/page.
+- Grading without enough later observations → `wait_for_window`, never invent improvement.
+- Legacy workspaces without project.yaml → decide exits non-zero asking for the portable contract.
+
+## Migration Plan
+
+1. Spec + tests for ranking and ledger append.
+2. Implement `decide` as a loop subcommand.
+3. Dry-run against the live SlashStack workspace (read-only).
+4. PR, no merge without owner gate.

--- a/openspec/changes/add-loop-decision-layer/proposal.md
+++ b/openspec/changes/add-loop-decision-layer/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add a deterministic loop decision layer
+
+## Why
+
+The loop already collects data and prints a run plan, but it does not decide the next unit of work or remember whether a previous action moved a metric. Without that, every wake-up still needs a human to interpret JSONL.
+
+## What Changes
+
+- Add `$EGEO_HOME/data/outcomes/ledger.jsonl` as an append-only, LLM-free outcome ledger.
+- Add `egeo loop decide [--dry-run] [--json]` that ranks one next action from collector data, project.yaml, and the ledger.
+- Write one proposal document under `$EGEO_HOME/docs/` when not dry-run. Never publish, merge, or edit site copy.
+- Grade open ledger rows at 7/14/28 days from later collector observations.
+- Keep `reflect.auto_apply` as the only autonomy gate; `decide` never applies.
+
+## Impact
+
+- Affected capability: `geo-loop-runtime`.
+- Affected code: `egeo/loop.py`, `egeo/workspace.py` (paths only if needed), docs, tests.
+- No credentials, no auto-publish, no auto-merge.

--- a/openspec/changes/add-loop-decision-layer/specs/geo-loop-runtime/spec.md
+++ b/openspec/changes/add-loop-decision-layer/specs/geo-loop-runtime/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Decision Command Ranks One Next Action
+
+The CLI SHALL expose `egeo loop decide [--dry-run] [--json]`. The command SHALL be LLM-free, SHALL require a valid `project.yaml`, and SHALL emit exactly one ranked action from collector JSONL, the project contract, and the outcome ledger.
+
+#### Scenario: Target absent from SERP
+
+- **WHEN** an active query has `target_position: null` in at least three observations
+- **THEN** the ranked action kind is `escalate_absent`
+- **AND** the action cites the SERP stream path
+- **AND** `next_gate` is `owner`
+
+#### Scenario: Dry run writes nothing
+
+- **WHEN** `egeo loop decide --dry-run` runs against a valid workspace
+- **THEN** the ranked action is printed
+- **AND** no ledger row, proposal doc, or extra LOG line is written
+
+### Requirement: Outcome Ledger Is Append-Only
+
+Decision outcomes SHALL be appended to `$EGEO_HOME/data/outcomes/ledger.jsonl`. Existing lines SHALL never be rewritten. Each record SHALL include schema version `v`, `id`, `ts`, `project_id`, `kind`, `status`, evidence paths, and `auto_apply: false`.
+
+#### Scenario: Proposed action is recorded
+
+- **WHEN** `egeo loop decide` runs without `--dry-run` and ranks a new action
+- **THEN** exactly one new ledger line is appended with `status: proposed`
+- **AND** `auto_apply` is `false`
+- **AND** the command never sets `status: applied`
+
+#### Scenario: Duplicate open action is not re-proposed
+
+- **WHEN** an open ledger row already exists for the same kind and query/page IDs
+- **THEN** the ranked action is `wait_for_window` or `grade_outcome`
+- **AND** no second proposed row is appended
+
+### Requirement: Outcomes Are Graded From Later Observations
+
+When an open ledger row has reached a 7, 14, or 28 day window and newer collector observations exist, `decide` SHALL grade that row as `verified`, `unchanged`, `worse`, or `withdrawn` using only collector fields. It SHALL NOT invent metric movement.
+
+#### Scenario: Window reached with no position change
+
+- **WHEN** a proposed `escalate_absent` row is older than 7 days and later SERP observations still have null `target_position`
+- **THEN** the command records a grade of `unchanged` for that window
+- **AND** it does not claim improvement
+
+### Requirement: Decision Never Publishes
+
+`egeo loop decide` SHALL NOT edit the site, open a pull request, merge, deploy, or change `reflect.auto_apply`. Proposal documents SHALL name the owner gate.
+
+#### Scenario: Schema gap proposal
+
+- **WHEN** a tracked page has empty `jsonld_types`
+- **THEN** the ranked action kind is `propose_schema`
+- **AND** the proposal document states that visible copy must not be changed automatically

--- a/openspec/changes/add-loop-decision-layer/tasks.md
+++ b/openspec/changes/add-loop-decision-layer/tasks.md
@@ -1,0 +1,25 @@
+## 1. Spec and contract
+
+- [x] 1.1 Add OpenSpec delta for the decision layer.
+- [x] 1.2 Define ledger schema v1 and action kinds.
+
+## 2. Implementation
+
+- [x] 2.1 Implement ledger read/append and grading helpers (LLM-free).
+- [x] 2.2 Implement `egeo loop decide` with dry-run and JSON output.
+- [x] 2.3 Write at most one proposal doc and one LOG line when not dry-run.
+- [x] 2.4 Dedupe against open ledger rows; never set status `applied`.
+
+## 3. Tests
+
+- [x] 3.1 Rank `escalate_absent` from ≥3 null SERP observations.
+- [x] 3.2 Rank `propose_schema` from empty jsonld_types.
+- [x] 3.3 Rank `wait_for_window` when an open action has not matured.
+- [x] 3.4 Grade improved vs unchanged from later observations.
+- [x] 3.5 Dry-run writes nothing; invalid project.yaml fails closed.
+
+## 4. Verification
+
+- [x] 4.1 `openspec validate add-loop-decision-layer --strict`
+- [x] 4.2 Unit tests + compileall + git diff --check
+- [x] 4.3 Dry-run against a temp workspace cloned from SlashStack collector data (no writes to ~/.egeo)

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -120,7 +120,7 @@ Additional hosts can be added by implementing the `RuntimeAdapter` interface in 
 Loop mode keeps state in a per-user workspace (`$EGEO_HOME`, default `~/.egeo`). These commands are the scheduler seam and make **zero LLM calls**.
 
 ```
-usage: egeo loop [-h] {run,collect,doctor} ...
+usage: egeo loop [-h] {run,collect,doctor,decide} ...
 ```
 
 ### `egeo loop run <domain> [--dry-run] [--json]`
@@ -139,6 +139,10 @@ egeo loop collect page --url https://example.com/pricing
 ### `egeo loop doctor [--json]`
 
 Bootstrap the workspace if needed, then self-check it: layout, config, substrate, budgets.
+
+### `egeo loop decide [--dry-run] [--json]`
+
+Rank exactly one next action from `project.yaml`, collector JSONL, and `$EGEO_HOME/data/outcomes/ledger.jsonl`. LLM-free. `--dry-run` writes nothing. Without it, the command may append one ledger row and one proposal doc. It never publishes, merges, or sets `status: applied`.
 
 Full loop-mode guide: [GEO Loop](/docs/geo-loop/).
 

--- a/site/src/content/docs/docs/geo-loop.md
+++ b/site/src/content/docs/docs/geo-loop.md
@@ -50,11 +50,14 @@ configuration remains runnable and `egeo loop doctor` reports the fallback.
 Copy the shape from [`examples/project.yaml`](https://github.com/mverab/eGEOagents/blob/main/examples/project.yaml).
 The contract contains no API keys, OAuth tokens, or private Search Console data.
 
+`egeo loop decide` ranks **one** next action from that contract plus collector JSONL and `$EGEO_HOME/data/outcomes/ledger.jsonl`. It is LLM-free and never publishes. `--dry-run` writes nothing.
+
 ## Commands
 
 | Command | What it does |
 |---------|--------------|
 | `egeo loop doctor` | Bootstrap the workspace if missing, then health-check it (layout, config, budgets, substrate lint) |
+| `egeo loop decide` | Rank exactly one next action from collector JSONL + the outcome ledger (LLM-free; never publishes) |
 | `egeo loop collect serp` | Record a search-result snapshot (Brave API) into `data/serp/*.jsonl` |
 | `egeo loop collect page` | Record a page snapshot (hash, title, meta, JSON-LD types, word count) into `data/page/*.jsonl` |
 | `egeo loop run <domain>` | Resolve and print the run plan — current focus, fresh collector deltas, candidate signals |

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -1,0 +1,170 @@
+"""Tests for the deterministic loop decision layer."""
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+from egeo import decide, workspace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "examples" / "project.yaml"
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+
+
+def _write_jsonl(path: Path, records: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in records), encoding="utf-8")
+
+
+class DecideTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.home = Path(tempfile.mkdtemp(prefix="egeo-decide-"))
+        shutil.copy(EXAMPLE, self.home / workspace.PROJECT_CONFIG_NAME)
+        workspace.bootstrap(self.home)
+        project = workspace.load_project_config(self.home)
+        if not project:
+            raise AssertionError("examples/project.yaml must load")
+        self.project = project
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.home)
+
+    def _serp(self, query_text: str, positions, start: datetime | None = None) -> None:
+        start = start or (NOW - timedelta(days=3))
+        records = []
+        for index, position in enumerate(positions):
+            ts = start + timedelta(days=index)
+            records.append(
+                {
+                    "v": 1,
+                    "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "query": query_text,
+                    "target_position": position,
+                    "results": [],
+                }
+            )
+        _write_jsonl(decide._query_stream(self.home, query_text), records)
+
+    def _page(self, url: str, types, ts: datetime | None = None) -> None:
+        ts = ts or NOW
+        _write_jsonl(
+            decide._page_stream(self.home, url),
+            [
+                {
+                    "v": 1,
+                    "ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "url": url,
+                    "status": 200,
+                    "jsonld_types": types,
+                    "content_hash": "abc",
+                    "word_count": 10,
+                }
+            ],
+        )
+
+    def _fresh_all_pages(self) -> None:
+        for page in self.project["pages"]:
+            self._page(page["url"], ["WebPage"], NOW)
+
+    def test_escalate_absent_from_three_nulls(self) -> None:
+        self._serp("GEO evaluation harness open source", [None, None, None])
+        self._fresh_all_pages()
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        self.assertEqual(action["kind"], "escalate_absent")
+        self.assertEqual(action["query_ids"], ["generic-geo-evaluation"])
+        self.assertEqual(action["next_gate"], "owner")
+        self.assertFalse(action["auto_apply"])
+
+    def test_propose_schema_when_jsonld_empty(self) -> None:
+        self._serp("GEO evaluation harness open source", [1, 1, 1])
+        self._serp("what is llms.txt", [2, 2, 2])
+        self._serp("E-GEO generative engine optimization toolkit", [3, 3, 3])
+        for page in self.project["pages"]:
+            types = [] if page["id"] == "home" else ["WebPage"]
+            self._page(page["url"], types, NOW)
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        self.assertEqual(action["kind"], "propose_schema")
+        self.assertEqual(action["page_ids"], ["home"])
+
+    def test_wait_for_window_when_open_action_is_fresh(self) -> None:
+        self._serp("GEO evaluation harness open source", [None, None, None])
+        self._fresh_all_pages()
+        decide.append_jsonl(
+            decide.ledger_path(self.home),
+            {
+                "v": 1,
+                "id": "open-row",
+                "ts": (NOW - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "kind": "escalate_absent",
+                "status": "proposed",
+                "query_ids": ["generic-geo-evaluation"],
+                "page_ids": ["docs-evaluation"],
+                "auto_apply": False,
+            },
+        )
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        self.assertEqual(action["kind"], "wait_for_window")
+
+    def test_grade_unchanged_after_seven_days(self) -> None:
+        created = NOW - timedelta(days=8)
+        self._serp("GEO evaluation harness open source", [None, None, None, None], start=created - timedelta(days=2))
+        self._fresh_all_pages()
+        decide.append_jsonl(
+            decide.ledger_path(self.home),
+            {
+                "v": 1,
+                "id": "old-row",
+                "ts": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "kind": "escalate_absent",
+                "status": "proposed",
+                "query_ids": ["generic-geo-evaluation"],
+                "page_ids": ["docs-evaluation"],
+                "grades": {},
+                "auto_apply": False,
+            },
+        )
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        self.assertEqual(action["kind"], "grade_outcome")
+        self.assertEqual(action["grade"], "unchanged")
+
+    def test_dry_run_writes_nothing(self) -> None:
+        self._serp("GEO evaluation harness open source", [None, None, None])
+        self._fresh_all_pages()
+        before_log = (self.home / "LOG.md").read_text(encoding="utf-8")
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        self.assertEqual(action["kind"], "escalate_absent")
+        self.assertFalse(decide.ledger_path(self.home).exists())
+        self.assertEqual((self.home / "LOG.md").read_text(encoding="utf-8"), before_log)
+        docs = list((self.home / "docs").glob("*.md")) if (self.home / "docs").is_dir() else []
+        self.assertEqual(docs, [])
+
+    def test_apply_never_sets_applied(self) -> None:
+        self._serp("GEO evaluation harness open source", [None, None, None])
+        self._fresh_all_pages()
+        action = decide.rank_action(self.home, self.project, now=NOW)
+        result = decide.apply_decision(self.home, self.project, action, now=NOW)
+        row = result["ledger_row"]
+        self.assertEqual(row["status"], "proposed")
+        self.assertFalse(row["auto_apply"])
+        self.assertNotEqual(row["status"], "applied")
+        ledger = decide.load_ledger(self.home)
+        self.assertEqual(len(ledger), 1)
+        self.assertTrue(any("docs/" in item for item in result["written"]))
+
+    def test_duplicate_open_row_is_not_reproposed(self) -> None:
+        self._serp("GEO evaluation harness open source", [None, None, None])
+        self._fresh_all_pages()
+        first = decide.rank_action(self.home, self.project, now=NOW)
+        decide.apply_decision(self.home, self.project, first, now=NOW)
+        second = decide.rank_action(self.home, self.project, now=NOW + timedelta(hours=1))
+        self.assertEqual(second["kind"], "wait_for_window")
+        self.assertEqual(len(decide.load_ledger(self.home)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Adds `egeo loop decide [--dry-run] [--json]`: LLM-free ranking of exactly one next action from `project.yaml`, collector JSONL, and `$EGEO_HOME/data/outcomes/ledger.jsonl`.

## Enforcement
- requires a valid `project.yaml` (legacy config is not enough)
- invalid contracts fail closed
- `--dry-run` writes nothing
- live writes: at most one ledger row (`status: proposed`), one proposal doc, one LOG line
- never sets `status: applied`, never edits the site, never opens a PR

## Ranking (table order)
`collect_fresh` → `wait_for_window` → `grade_outcome` → `escalate_absent` → `propose_page_owner` → `propose_schema` → `no_op`

## Verification
- 7 new unit tests + existing portable-contract tests green
- OpenSpec strict green
- site build + verify.sh green
- SlashStack collector data dry-run (copy of `~/.egeo`, no writes to the live workspace): `escalate_absent` for `agent-operating-system`, `next_gate: owner`
- invalid `project.yaml`: rc=1, 0 JSONL

## Gate
Not merged. Owner merge required.