### PR TITLE
docs: visibility case study + PyPI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://github.com/mverab/eGEOagents/network/members"><img src="https://img.shields.io/github/forks/mverab/eGEOagents?style=social" alt="GitHub Forks" /></a>
   <a href="https://github.com/mverab/eGEOagents/issues"><img src="https://img.shields.io/github/issues/mverab/eGEOagents" alt="Issues" /></a>
   <a href="https://arxiv.org/abs/2511.20867"><img src="https://img.shields.io/badge/arXiv-2511.20867-b31b1b.svg" alt="Research Paper" /></a>
+  <a href="https://pypi.org/project/egeo/"><img src="https://img.shields.io/pypi/v/egeo" alt="PyPI" /></a>
 </p>
 
 <p>
@@ -250,12 +251,10 @@ duplicated optimization logic** — both runtimes share one source of truth.
 ### Install
 
 ```bash
-# From the repo root — installs the `egeo` console script + deps
-pip install -e .
-
-# ...or run without installing (deps: pip install pyyaml jsonschema)
-python -m egeo --help
+pip install egeo
 ```
+
+From a clone, `pip install -e .` still works. `python -m egeo --help` runs without installing (deps: `pip install pyyaml jsonschema`).
 
 ### Commands
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -3,7 +3,8 @@
 > E-GEO — open-source Generative Engine Optimization (GEO) & Answer Engine Optimization (AEO) toolkit (Python CLI + Claude Code skills), based on published GEO research (arXiv:2511.20867).
 
 Site: https://egeoagents.com
-Source: https://github.com/mverab/eGEOagents (MIT license; 147 stars, 42 forks as of 2026-08)
+Source: https://github.com/mverab/eGEOagents (MIT license; 168 stars, 47 forks as of 2026-08-31)
+PyPI: https://pypi.org/project/egeo/
 Paper: https://arxiv.org/abs/2511.20867
 Skills: https://skills.sh/mverab/egeoagents
 
@@ -21,8 +22,8 @@ Differentiators:
 ## Install
 
 Standalone Python CLI:
-    git clone https://github.com/mverab/eGEOagents.git && cd eGEOagents
-    pip install -e .        # or: python -m egeo --help
+    pip install egeo
+    # clone + pip install -e . still works; or: python -m egeo --help
 Claude Code skills:
     npx skills add https://github.com/mverab/eGEOagents
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > E-GEO — open-source Generative Engine Optimization (GEO) & Answer Engine Optimization (AEO) toolkit (Python CLI + Claude Code skills), based on published GEO research (arXiv:2511.20867).
 
-E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered search engines: ChatGPT, Perplexity, Gemini, and Claude. It runs a full pipeline — analyze, rank-simulate, rewrite, generate JSON-LD schema — as a standalone Python CLI (`egeo`) or as Claude Code agents and skills. It ships a reproducible evaluation harness (offline, deterministic, no API key via GEO_EVAL_MOCK=1), a continuous geo-loop mode over a persistent workspace ($EGEO_HOME), llms.txt support, and schema markup generation. MIT licensed. Source: https://github.com/mverab/eGEOagents (147 stars as of 2026-08). Install: `pip install -e .` or `npx skills add https://github.com/mverab/eGEOagents`.
+E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered search engines: ChatGPT, Perplexity, Gemini, and Claude. It runs a full pipeline — analyze, rank-simulate, rewrite, generate JSON-LD schema — as a standalone Python CLI (`egeo`) or as Claude Code agents and skills. It ships a reproducible evaluation harness (offline, deterministic, no API key via GEO_EVAL_MOCK=1), a continuous geo-loop mode over a persistent workspace ($EGEO_HOME), llms.txt support, and schema markup generation. MIT licensed. Source: https://github.com/mverab/eGEOagents (168 stars as of 2026-08-31). PyPI: https://pypi.org/project/egeo/. Install: `pip install egeo` or `npx skills add https://github.com/mverab/eGEOagents`.
 
 ## Docs
 
@@ -35,6 +35,7 @@ E-GEO analyzes, scores, and rewrites content to rank and get cited in AI-powered
 ## Optional
 
 - [Research behind E-GEO](https://egeoagents.com/research/): Princeton KDD 2024 + the E-GEO preprint, and how findings map to code
+- [Visibility case study](https://egeoagents.com/case-study/): weekly Perplexity measurements 2026-08-05–2026-08-24; head query still false
 - [Research paper (arXiv:2511.20867)](https://arxiv.org/abs/2511.20867): the research behind E-GEO
 - [GitHub repository](https://github.com/mverab/eGEOagents): source code, issues, discussions
 - [skills.sh collection](https://skills.sh/mverab/egeoagents): Claude Code skills distribution

--- a/site/src/content/docs/case-study.md
+++ b/site/src/content/docs/case-study.md
@@ -1,0 +1,82 @@
+---
+title: We Measured Our Own AI-Search Invisibility
+description: Three weeks of a fixed Perplexity query set on an open-source GEO tool that did not show up — what moved, what did not, and what we still cannot claim.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "We Measured Our Own AI-Search Invisibility",
+        "description": "Weekly Perplexity measurements of E-GEO from 2026-08-05 to 2026-08-24: branded mentions, one fragile generic hit, and a still-false head query.",
+        "url": "https://egeoagents.com/case-study/",
+        "datePublished": "2026-08-31",
+        "dateModified": "2026-08-31",
+        "author": {"@type": "Person", "name": "Miguel Vera", "sameAs": ["https://github.com/mverab"]}
+      }
+---
+
+**Last verified: 2026-08-24.** Six snapshots. Same 10 queries. Same model (`sonar`). This is not six months of data and it is not a ranking guarantee.
+
+E-GEO is an open-source GEO/AEO toolkit. For a month we optimized the repo (topics, description, README) and still did not appear when Perplexity was asked the category question: *What are the best open-source generative engine optimization (GEO) tools on GitHub in 2026?*
+
+That query is still **false** on every snapshot. This page is the measurement log, not a success story.
+
+## What we measured
+
+A fixed set of 10 queries, weekly, via Perplexity Sonar. A mention is a binary: the answer text referred to E-GEO / eGEOagents. Branded queries are not treated as category wins.
+
+| Date | Mentions | Head query (best OSS GEO tools on GitHub 2026) | Generic (non-branded) hits |
+|---|---|---|---|
+| 2026-08-05 | 2/10 | false | none |
+| 2026-08-09 | 2/10 | false | none |
+| 2026-08-10 | 3/10 | false | `GEO evaluation harness open source` |
+| 2026-08-11 | 3/10 | false | same |
+| 2026-08-17 | 4/10 | false | harness + `open source tool to rank in ChatGPT and Perplexity` |
+| 2026-08-24 | 3/10 | false | harness only (the extra 2026-08-17 hit did not hold) |
+
+The two branded queries (`eGEOagents`, `eGEOagents GitHub`) were true from day one. They do not count as category visibility.
+
+Single-run answers vary. 3/10 on 2026-08-24 is one sample, not a trend. We do not launch a course off it.
+
+## What actually changed off-repo
+
+On-repo metadata was already exhausted by 2026-08-05. After that we shipped external surfaces:
+
+| Surface | When | Status |
+|---|---|---|
+| Docs site [egeoagents.com](https://egeoagents.com) | 2026-08 | live |
+| [LibHunt listing](https://www.libhunt.com/r/eGEOagents) | 2026-08-09 | live, auto-approved |
+| GitHub Sponsors + a $199 GEO audit | 2026-08 | live |
+| [`egeo` on PyPI](https://pypi.org/project/egeo/) | 2026-08-31 | live (`pip install egeo`) |
+
+GitHub stars moved 147 → 168 over the same window. The head query did not. Stars were never the bottleneck — projects with 17–37 stars already appeared in that answer because they were in the sources Perplexity cites.
+
+## What we still cannot claim
+
+- We are **not** in the head-query ranking. geo-optimizer-skill, geo-lint, xanlens, open-geo, GEO-optim/GEO, and the izak-fisher / amplifying-ai lists still are.
+- The 2026-08-17 extra generic mention **regressed** the following week.
+- PyPI shipped *after* the last snapshot. It cannot be credited for 3/10.
+- arXiv:2511.20867 is a **preprint**, not a peer-reviewed paper. The peer-reviewed GEO anchor is Aggarwal et al., KDD 2024 ([arXiv:2311.09735](https://arxiv.org/abs/2311.09735)).
+- E-GEO consumes MCP servers as a **client**. It is not an MCP server.
+- Indexation, crawl, and citation are different events. We do not claim Google or Perplexity will index or cite a URL because we asked.
+
+## Method, so you can repeat it
+
+1. Freeze 8–10 queries. Do not edit them week to week.
+2. Ask the same engine. Record mention yes/no, competitors named, and **cited domains**.
+3. Treat cited domains as the distribution list. In this category that was LibHunt first, then awesome-lists and dated comparison pages.
+4. Do not read a branded hit as a category win.
+5. Re-run a one-week spike before acting on it.
+
+The playbook distilled from this log is in [How to get cited by Perplexity](/guides/rank-in-perplexity/). The research lineage is on [/research/](/research/).
+
+## Next measurement
+
+The next weekly snapshot is 2026-08-31. Gate A in our public plan is **≥3/10 sustained or ≥300 GitHub stars**. Today: 3/10 on one later snapshot, 168 stars. Neither bar is met.
+
+---
+
+**In short:** a GEO tool with a polished README still does not exist to Perplexity until curator sources name it. We measured that on ourselves. The head query remains unanswered by us. [Install `egeo`](https://pypi.org/project/egeo/) or read the [source](https://github.com/mverab/eGEOagents).

--- a/site/src/content/docs/compare/e-geo-vs-geo-optimizer-skill.md
+++ b/site/src/content/docs/compare/e-geo-vs-geo-optimizer-skill.md
@@ -64,9 +64,10 @@ head:
 ## Try E-GEO
 
 ```bash
-git clone https://github.com/mverab/eGEOagents.git && cd eGEOagents
-pip install -e .
+pip install egeo
 GEO_EVAL_MOCK=1 egeo optimize examples/sample-input.md
 ```
+
+(`examples/sample-input.md` is in the [repo](https://github.com/mverab/eGEOagents).)
 
 See also: [Open-Source GEO Tools in 2026](/compare/geo-tools-2026/).

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -16,7 +16,7 @@ head:
       }
 ---
 
-The `egeo` CLI (v2.0.0) is a runtime-agnostic wrapper around the same `geo_eval.py` and `llm_client.py` modules used by the Claude Code agents. Install with `pip install -e .` from the repo root, or run `python -m egeo` without installing.
+The `egeo` CLI (v2.0.0) is a runtime-agnostic wrapper around the same `geo_eval.py` and `llm_client.py` modules used by the Claude Code agents. Install with `pip install egeo`, or run `python -m egeo` from a clone without installing.
 
 ```
 usage: egeo [-h] [--version] {optimize,evaluate,optimize-prompts,runtimes,loop} ...

--- a/site/src/content/docs/docs/faq.md
+++ b/site/src/content/docs/docs/faq.md
@@ -64,7 +64,7 @@ Full comparison: [E-GEO vs geo-optimizer-skill](/compare/e-geo-vs-geo-optimizer-
 **Yes.** The standalone `egeo` Python CLI runs the full pipeline anywhere Python runs — local shells, notebooks, Docker, CI:
 
 ```bash
-pip install -e .
+pip install egeo
 egeo optimize path/to/page.md
 ```
 

--- a/site/src/content/docs/docs/getting-started.md
+++ b/site/src/content/docs/docs/getting-started.md
@@ -30,12 +30,10 @@ E-GEO runs in two ways: as a **standalone Python CLI** (`egeo`) or as a set of *
 ### Option 1: Standalone Python CLI
 
 ```bash
-git clone https://github.com/mverab/eGEOagents.git
-cd eGEOagents
-pip install -e .
+pip install egeo
 ```
 
-Or run without installing:
+From a clone, `pip install -e .` still works. Or run without installing:
 
 ```bash
 pip install pyyaml jsonschema

--- a/site/src/content/docs/research.md
+++ b/site/src/content/docs/research.md
@@ -54,6 +54,8 @@ What it reports:
 
 Because a GEO tool whose own claims can't be traced to sources is selling the exact disease it claims to cure. Every claim on this site links to its ground truth — code, paper, or measured data — and the [comparison pages](/compare/geo-tools-2026/) credit competitors' real strengths, including the one with more stars than us.
 
+The measurement log of applying that rule to E-GEO itself is the [visibility case study](/case-study/) (weekly Perplexity snapshots from 2026-08-05; head query still false).
+
 ---
 
 **In short:** E-GEO stands on the peer-reviewed Princeton GEO study (KDD 2024) plus the project's own applied preprint (arXiv:2511.20867), and every finding maps to a specific, inspectable part of the codebase. Verify, don't trust: [github.com/mverab/eGEOagents](https://github.com/mverab/eGEOagents).


### PR DESCRIPTION
## Summary
- Adds `/case-study/` — weekly Perplexity log 2026-08-05 → 2026-08-24. Head query still false. 4/10 on 2026-08-17 did not hold.
- Install path is now `pip install egeo` (PyPI 2.0.0 live). Badge on README. Stars in `llms.txt` updated to 168 as of 2026-08-31.

Does **not** merge itself. Does not post to Reddit/HN. Does not claim Gate A.

## Test plan
- [x] `npm run build` includes `/case-study/` in sitemap
- [x] `site/verify.sh` all checks passed
- [x] https://pypi.org/project/egeo/ HTTP 200